### PR TITLE
fixed dockerfile issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 
 
 # Run a custom ssl_setup script if available
-COPY ./docker_ssl_setup.sh ./
+COPY package.json ./docker_ssl_setup.sh* ./
 RUN chmod +x ./docker_ssl_setup.sh; exit 0
 RUN ./docker_ssl_setup.sh; exit 0
 ENV NODE_EXTRA_CA_CERTS="/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
## Summary
Quick patch that allows the dockerfile to build the image without crashing in the absence of a docker_ssl_setup.sh file

### New behavior
The docker image will not crash on build in the absence of a docker_ssl_setup.sh file

### Code changes
Added a wildcard to the end of docker_ssl_setup.sh on the copy step and now copy the readme.md before it to ensure the build doesn't crash

## Testing guidance
run `docker build -t bulk-export-server . ` and ensure it builds, then delete `docker_ssl_setup.sh` and run the same command again and ensure that it fails on the `npm install` with `exit 1`
