### PR TITLE
Update bulk status to respond with FHIR type not file name

### DIFF
--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -1,5 +1,7 @@
 const { getBulkExportStatus, BULKSTATUS_COMPLETED, BULKSTATUS_INPROGRESS } = require('../util/mongo.controller');
 const fs = require('fs');
+const path = require('path');
+
 /**
  * Checks the status of the bulk export request.
  * @param {*} request the request object passed in by the user
@@ -48,7 +50,10 @@ async function getNDJsonURLs(reply, clientId) {
   }
   const output = [];
   files.forEach(file => {
-    const entry = { type: file, url: `http://${process.env.HOST}:${process.env.PORT}/${clientId}/${file}` };
+    const entry = {
+      type: path.basename(file, '.ndjson'),
+      url: `http://${process.env.HOST}:${process.env.PORT}/${clientId}/${file}`
+    };
     output.push(entry);
   });
   return output;

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -36,7 +36,7 @@ describe('checkBulkStatus logic', () => {
         expect(response.headers.expires).toBeDefined();
         expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
         expect(response.body.outcome).toEqual([
-          { type: 'Patient.ndjson', url: `http://localhost:3000/${clientId}/Patient.ndjson` }
+          { type: 'Patient', url: `http://localhost:3000/${clientId}/Patient.ndjson` }
         ]);
       });
   });


### PR DESCRIPTION
When I was reviewing this code, I missed that the `type` part of the returned export data should just be a fhir resource type, not the file name. This PR strips off the `.ndjson` extension and updates the test properly.

To test, run an export and then hit the bulkstatus endpoint after it completes. The `type`s should be FHIR types, not file names now.