### PR TITLE
updated spec discrepancies

### DIFF
--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -22,7 +22,7 @@ async function checkBulkStatus(request, reply) {
     reply.send({
       transactionTime: new Date(),
       requiresAccessToken: false,
-      outcome: responseData,
+      output: responseData,
       // When we eventually catch warnings, this will add them to the response object
       ...(bulkStatus.warnings.length === 0
         ? undefined

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -12,7 +12,7 @@ const bulkExport = async (request, reply) => {
     request.log.info('Base >>> $export');
     const clientEntry = await addPendingBulkExportRequest();
     exportToNDJson(clientEntry, request);
-    reply.code(202).header('Content-location', `/bulkstatus/${clientEntry}`).send();
+    reply.code(202).header('Content-location', `http://localhost:3000/bulkstatus/${clientEntry}`).send();
   }
 };
 

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -12,7 +12,10 @@ const bulkExport = async (request, reply) => {
     request.log.info('Base >>> $export');
     const clientEntry = await addPendingBulkExportRequest();
     exportToNDJson(clientEntry, request);
-    reply.code(202).header('Content-location', `http://localhost:3000/bulkstatus/${clientEntry}`).send();
+    reply
+      .code(202)
+      .header('Content-location', `http://${process.env.HOST}:${process.env.PORT}/bulkstatus/${clientEntry}`)
+      .send();
   }
 };
 

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -38,7 +38,7 @@ describe('checkBulkStatus logic', () => {
       .then(response => {
         expect(response.headers.expires).toBeDefined();
         expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
-        expect(response.body.outcome).toEqual([
+        expect(response.body.output).toEqual([
           { type: 'Patient', url: `http://localhost:3000/${clientId}/Patient.ndjson` }
         ]);
       });
@@ -74,7 +74,7 @@ describe('checkBulkStatus logic', () => {
       .then(response => {
         expect(response.headers.expires).toBeDefined();
         expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
-        expect(response.body.outcome).toEqual([
+        expect(response.body.output).toEqual([
           { type: 'Patient', url: `http://localhost:3000/REQUEST_WITH_WARNINGS/Patient.ndjson` }
         ]);
         expect(response.body.error).toEqual([


### PR DESCRIPTION
# Summary
Updated a minor discrepancies between our implementation of bulk export and the HL7 IG

## New behavior
- The url found in the `content-location` header of an $export request response is now an absolute url rather than a relative url
- The results of a successful bulkstatus requests after completing an export are now stored on `response.data.output` instead of `response.data.outcome`

## Code changes
- Made above two changes
- Updated testing

# Testing guidance
- Run the unit tests
- Boot up the server and send a `GET` request to `http://localhost:3000/$export`
- Ensure the `content-location` response header is an absolute url (ex. `http://localhost:3000/bulkstatus/{CLIENT_ID}` instead of `bulkstatus/{CLIENT_ID}`
- Send a `GET` request to the `content-location` header url and ensure that the array storing the paths to the NDJson files is under the `output` property instead of the `outcome` property
