### PR TITLE
small patch

### DIFF
--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -53,7 +53,10 @@ const exportToNDJson = async (clientId, request) => {
 
 const getDocuments = async (db, collectionName) => {
   const query = {};
-  let doc = await db.collection(collectionName.toString()).find(query).toArray();
+  let doc = await db
+    .collection(collectionName.toString())
+    .find(query, { projection: { _id: 0 } })
+    .toArray();
   return { document: doc, collectionName: collectionName.toString() };
 };
 


### PR DESCRIPTION
# Summary
We were including the _id in NDJson which messed with repeated import into the test server. This patch removes the _id property

## New behavior
Exported NDJson will no longer contain the _id field

## Code changes
Added projection to mongo query to remove _id field

# Testing guidance
Try conducting a bulk export and inspect the NDJson output. It should no longer contain the _id field. For more on conducting bulk exports check out this [PR](https://github.com/projecttacoma/bulk-export-server/pull/6)
