### PR TITLE
Child Process Functionality

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@ DB_NAME = bulk-export-server
 HOST = localhost
 PORT = 3000
 EXPORT_WORKERS = 2
+REDIS_HOST = localhost
+REDIS_PORT= 6379

--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ DB_PORT = 27017
 DB_NAME = bulk-export-server
 HOST = localhost
 PORT = 3000
+EXPORT_WORKERS = 2

--- a/src/resources/exportQueue.js
+++ b/src/resources/exportQueue.js
@@ -1,20 +1,14 @@
+// Setup for import queue which pushes jobs to Redis
+
 const Queue = require('bee-queue');
-const { exportToNDJson } = require('../util/exportToNDJson');
 
 const queueOptions = {
-  removeOnSuccess: true
+  removeOnSuccess: true,
+  isWorker: false
 };
 
 // Create a new queue to establish new Redis connection
 const exportQueue = new Queue('export', queueOptions);
-
-// This handler pulls down the jobs on Redis to handle
-exportQueue.process(async job => {
-  // Payload of createJob exists on job.data
-  const { clientEntry, types } = job.data;
-  // Call the existing export ndjson function that writes the files
-  await exportToNDJson(clientEntry, types);
-});
 
 exportQueue.on('error', err => {
   console.log('queue error: ', err);

--- a/src/resources/exportQueue.js
+++ b/src/resources/exportQueue.js
@@ -1,8 +1,11 @@
 // Setup for import queue which pushes jobs to Redis
-
 const Queue = require('bee-queue');
 
 const queueOptions = {
+  redis: {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: process.env.REDIS_PORT || 6379
+  },
   removeOnSuccess: true,
   isWorker: false
 };

--- a/src/server/exportWorker.js
+++ b/src/server/exportWorker.js
@@ -1,0 +1,28 @@
+const { client } = require('../util/mongo.js');
+const { exportToNDJson } = require('../util/exportToNDJson');
+const Queue = require('bee-queue');
+
+console.log(`export-worker-${process.pid}: Export Worker Started!`);
+
+const exportQueue = new Queue('export', {
+  redis: {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: process.env.REDIS_PORT || 6379
+  },
+  removeOnSuccess: true
+});
+
+// This handler pulls down the jobs on Redis to handle
+exportQueue.process(async job => {
+  // Payload of createJob exists on job.data
+  const { clientEntry, types } = job.data;
+  await client.connect();
+  // Call the existing export ndjson function that writes the files
+  const result = await exportToNDJson(clientEntry, types);
+  if (result) {
+    console.log(`export-worker-${process.pid}: Completed Export Request: ${clientEntry}`);
+  } else {
+    console.log(`export-worker-${process.pid}: Failed Export Request: ${clientEntry}`);
+  }
+  await client.close();
+});

--- a/src/server/exportWorker.js
+++ b/src/server/exportWorker.js
@@ -16,6 +16,7 @@ const exportQueue = new Queue('export', {
 exportQueue.process(async job => {
   // Payload of createJob exists on job.data
   const { clientEntry, types } = job.data;
+  console.log(`export-worker-${process.pid}: Processing Request: ${clientEntry}`);
   await client.connect();
   // Call the existing export ndjson function that writes the files
   const result = await exportToNDJson(clientEntry, types);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,4 +1,6 @@
 const mongoUtil = require('../util/mongo');
+const childProcess = require('child_process');
+const os = require('os');
 
 const server = require('./app')({ logger: { prettyPrint: true } });
 
@@ -7,6 +9,16 @@ const start = async () => {
     await server.listen(process.env.PORT, process.env.HOST);
     await mongoUtil.client.connect();
     server.log.info('Connected to the server!');
+
+    if (process.env.EXPORT_WORKERS > os.cpus().length) {
+      console.warn(
+        `WARNING: Requested to start ${process.env.EXPORT_WORKERS} workers with only ${os.cpus().length} available cpus`
+      );
+    }
+
+    for (let i = 0; i < process.env.EXPORT_WORKERS; i++) {
+      childProcess.fork('./src/server/exportWorker.js');
+    }
   } catch (err) {
     server.log.error(err);
     process.exit(1);

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -46,8 +46,10 @@ const exportToNDJson = async (clientId, types) => {
 
     // mark bulk status job as complete after all files have been written
     await updateBulkExportStatus(clientId, BULKSTATUS_COMPLETED);
+    return true;
   } catch (e) {
     await updateBulkExportStatus(clientId, BUlKSTATUS_FAILED, { message: e.message, code: 500 });
+    return false;
   }
 };
 


### PR DESCRIPTION
# Summary
Updated the Bee-Queue configuration to spin up child processes at server startup to handle bulk data requests

## New behavior
Hopefully none while interacting with the server, with the exception of a couple new logs, but all bulk data requests will now be handled in child processes preventing the server from being blocked by processing.

## Code changes
- Added ExportWorker.js file with all code to process bulk export requests
- Updated server.js to spin up

# Testing guidance
- Start up the server with `PORT=3001 npm run start`
- You should now see `export-worker-{PID}: Export Worker Started!` log twice
- Try spamming export requests to `http://localhost:3001/$export` (Ensure you have already reset the db and run a connectathon upload)
- You should see `export-worker-{PID}: Processing Request: {CLIENT_ID}` although it may get buried in the logs.
- Upon completion of the request, you should see `export-worker-{PID}: Completed Export Request: {CLIENT_ID}`
- Try sending a request to the bulkstatus endpoint to ensure that the request suceeds
- Now fire up the deqm-test-server using `npm run start`
- Kick off a `$import` request by POSTing a fhir parameters object with the exportUrl `http://localhost:3001/$export`
- Query the bulkstatus endpoint returned and ensure that the request suceeded
- Finally, power down both servers, then run `EXPORT_WORKERS=20 npm run start` in the bulk export server and ensure you get a warning about starting more processes than the number of available cpus.