### PR TITLE
Connectathon Changes

### DIFF
--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -2,9 +2,7 @@ const {
   getBulkExportStatus,
   BULKSTATUS_COMPLETED,
   BULKSTATUS_INPROGRESS,
-  updateLastBulkStatusRequest,
   resetFirstValidRequest,
-  updateFirstValidRequest,
   updateNumberOfRequestsInWindow
 } = require('../util/mongo.controller');
 const fs = require('fs');
@@ -12,6 +10,7 @@ const path = require('path');
 const { createOperationOutcome } = require('../util/errorUtils');
 
 const RETRY_AFTER = 1;
+//The number of requests we allow inside the retry after window before throwing a 429 error
 const REQUEST_TOLERANCE = 10;
 
 /**

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -67,6 +67,12 @@ async function checkBulkStatus(request, reply) {
   }
 }
 
+/**
+ * Returns true if the current time is later than the first valid request time plus the retry after buffer
+ * @param {Object} curTime A date object signifying the current time
+ * @param {Object} firstValidRequest A date object signifying the time of the first valid request
+ * @returns {boolean} true if the current time is later than the first valid request time plus the retry after buffer, false otherwise
+ */
 function checkTimeIsOutsideWindow(curTime, firstValidRequest) {
   const expectedTime = new Date(firstValidRequest);
   expectedTime.setSeconds(expectedTime.getSeconds() + RETRY_AFTER);

--- a/src/services/bulkstatus.service.js
+++ b/src/services/bulkstatus.service.js
@@ -8,9 +8,9 @@ const {
 const fs = require('fs');
 const path = require('path');
 const { createOperationOutcome } = require('../util/errorUtils');
-
+/** The time a client is expected to wait between bulkstatus requests in seconds*/
 const RETRY_AFTER = 1;
-//The number of requests we allow inside the retry after window before throwing a 429 error
+/** The number of requests we allow inside the retry after window before throwing a 429 error */
 const REQUEST_TOLERANCE = 10;
 
 /**
@@ -30,13 +30,15 @@ async function checkBulkStatus(request, reply) {
     if (!timeOfFirstValidRequest || checkTimeIsOutsideWindow(curTime, timeOfFirstValidRequest)) {
       await resetFirstValidRequest(clientId, curTime);
       reply.code(202);
+      reply.header('X-Progress', 'Exporting files');
     } else if (numberOfRequestsInWindow > REQUEST_TOLERANCE) {
       reply.code(429);
     } else {
       await updateNumberOfRequestsInWindow(clientId, numberOfRequestsInWindow + 1);
       reply.code(202);
+      reply.header('X-Progress', 'Exporting files');
     }
-    reply.header('X-Progress', 'Exporting files').header('Retry-After', RETRY_AFTER).send();
+    reply.header('Retry-After', RETRY_AFTER).send();
   } else if (bulkStatus.status === BULKSTATUS_COMPLETED) {
     reply.code(200).header('Expires', 'EXAMPLE_EXPIRATION_DATE');
     const responseData = await getNDJsonURLs(reply, clientId);

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -53,6 +53,12 @@ const exportToNDJson = async (clientId, types) => {
   }
 };
 
+/**
+ * Retrieves all documents from the requested collection and wraps in an object with the collection name
+ * @param {Object} db The mongo db that contains the requested data
+ * @param {string} collectionName The collection of interest in the mongo db
+ * @returns {Object} An object containing all data from the given collection name as well as the collection name
+ */
 const getDocuments = async (db, collectionName) => {
   const query = {};
   let doc = await db
@@ -62,6 +68,14 @@ const getDocuments = async (db, collectionName) => {
   return { document: doc, collectionName: collectionName.toString() };
 };
 
+/**
+ * Writed the contents of a mongo document to an ndjson file with the appropriate resource
+ * name, stored in a directory under the clients id
+ * @param {Object} doc A mongodb document containing fhir resources
+ * @param {string} type The fhir resource type contained in the mongo document
+ * @param {string} clientId The id of the client making the export request
+ * @returns
+ */
 const writeToFile = function (doc, type, clientId) {
   let dirpath = './tmp/' + clientId;
   fs.mkdirSync(dirpath, { recursive: true });

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -54,9 +54,9 @@ const exportToNDJson = async (clientId, types) => {
 };
 
 /**
- * Retrieves all documents from the requested collection and wraps in an object with the collection name
- * @param {Object} db The mongo db that contains the requested data
- * @param {string} collectionName The collection of interest in the mongo db
+ * Retrieves all documents from the requested collection and wraps them in an object with the collection name
+ * @param {Object} db The mongodb that contains the requested data
+ * @param {string} collectionName The collection of interest in the mongodb
  * @returns {Object} An object containing all data from the given collection name as well as the collection name
  */
 const getDocuments = async (db, collectionName) => {
@@ -69,10 +69,10 @@ const getDocuments = async (db, collectionName) => {
 };
 
 /**
- * Writed the contents of a mongo document to an ndjson file with the appropriate resource
- * name, stored in a directory under the clients id
+ * Writes the contents of a mongo document to an ndjson file with the appropriate resource
+ * name, stored in a directory under the client's id
  * @param {Object} doc A mongodb document containing fhir resources
- * @param {string} type The fhir resource type contained in the mongo document
+ * @param {string} type The fhir resourceType contained in the mongo document
  * @param {string} clientId The id of the client making the export request
  * @returns
  */

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -101,6 +101,8 @@ const addPendingBulkExportRequest = async () => {
   const bulkExportClient = {
     id: clientId,
     status: BULKSTATUS_INPROGRESS,
+    numberOfRequests: 0,
+    timeSinceLastRequest: null,
     error: {},
     warnings: []
   };

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -134,17 +134,28 @@ const updateBulkExportStatus = async (clientId, newStatus, error = null) => {
 };
 
 /**
- * @param {string} clientId
- * @param {Object} data
+ * Changes the first valid request time for tracking 429:TooManyRequests errors
+ * @param {string} clientId the id of the client making the export request
+ * @param {Object} timeOfFirstValidRequest a Date object storing the time of the first valid request
  */
 const updateFirstValidRequest = async (clientId, timeOfFirstValidRequest) => {
   await updateResource(clientId, { timeOfFirstValidRequest }, 'bulkExportStatuses');
 };
 
+/**
+ * Changes the number tracking the quantity of bulkstatus requests made within
+ * @param {*} clientId the id of the client making the export request
+ * @param {*} numberOfRequestsInWindow the new number of requests madde within the retry after window
+ */
 const updateNumberOfRequestsInWindow = async (clientId, numberOfRequestsInWindow) => {
   await updateResource(clientId, { numberOfRequestsInWindow }, 'bulkExportStatuses');
 };
 
+/**
+ * Sets the time of the first valid request and resets the number of requests made within the retry after window
+ * @param {*} clientId the id of the client making the export request
+ * @param {*} timeOfFirstValidRequest a Date object storing the time of the first valid request
+ */
 const resetFirstValidRequest = async (clientId, timeOfFirstValidRequest) => {
   await updateResource(clientId, { timeOfFirstValidRequest, numberOfRequestsInWindow: 1 }, 'bulkExportStatuses');
 };

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -101,8 +101,8 @@ const addPendingBulkExportRequest = async () => {
   const bulkExportClient = {
     id: clientId,
     status: BULKSTATUS_INPROGRESS,
-    numberOfRequests: 0,
-    timeSinceLastRequest: null,
+    numberOfRequestsInWindow: 0,
+    timeOfFirstValidRequest: null,
     error: {},
     warnings: []
   };
@@ -134,6 +134,22 @@ const updateBulkExportStatus = async (clientId, newStatus, error = null) => {
 };
 
 /**
+ * @param {string} clientId
+ * @param {Object} data
+ */
+const updateFirstValidRequest = async (clientId, timeOfFirstValidRequest) => {
+  await updateResource(clientId, { timeOfFirstValidRequest }, 'bulkExportStatuses');
+};
+
+const updateNumberOfRequestsInWindow = async (clientId, numberOfRequestsInWindow) => {
+  await updateResource(clientId, { numberOfRequestsInWindow }, 'bulkExportStatuses');
+};
+
+const resetFirstValidRequest = async (clientId, timeOfFirstValidRequest) => {
+  await updateResource(clientId, { timeOfFirstValidRequest, numberOfRequestsInWindow: 1 }, 'bulkExportStatuses');
+};
+
+/**
  * Adds a warning to the bulkstatus warning array
  * @param {*} clientId the client id for the request which threw the warning
  * @param {*} warning {message: string, code: int} an object with the message and code of the caught error
@@ -155,6 +171,9 @@ module.exports = {
   findResourcesWithAggregation,
   addPendingBulkExportRequest,
   pushBulkStatusWarning,
+  updateNumberOfRequestsInWindow,
+  updateFirstValidRequest,
+  resetFirstValidRequest,
   BULKSTATUS_INPROGRESS,
   BULKSTATUS_COMPLETED,
   BUlKSTATUS_FAILED

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -143,9 +143,9 @@ const updateFirstValidRequest = async (clientId, timeOfFirstValidRequest) => {
 };
 
 /**
- * Changes the number tracking the quantity of bulkstatus requests made within
+ * Changes the number tracking the quantity of bulkstatus requests made within the retry after window
  * @param {*} clientId the id of the client making the export request
- * @param {*} numberOfRequestsInWindow the new number of requests madde within the retry after window
+ * @param {*} numberOfRequestsInWindow the new number of requests made within the retry after window
  */
 const updateNumberOfRequestsInWindow = async (clientId, numberOfRequestsInWindow) => {
   await updateResource(clientId, { numberOfRequestsInWindow }, 'bulkExportStatuses');

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -101,7 +101,6 @@ describe('checkBulkStatus logic', () => {
     for (let i = 0; i <= 10; i++) {
       response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
     }
-    console.log(response);
     expect(response.statusCode).toEqual(429);
   });
   test('check 202 returned for spamming requests appropriately slowly', async () => {
@@ -110,7 +109,6 @@ describe('checkBulkStatus logic', () => {
     }
     await new Promise(resolve => setTimeout(resolve, 1000));
     const response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
-    console.log(response);
     expect(response.statusCode).toEqual(202);
   });
 

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -97,12 +97,21 @@ describe('checkBulkStatus logic', () => {
       });
   });
   test('check 429 error returned for spamming requests', async () => {
-    let response = {};
-    for (i = 0; i <= 10; i++) {
+    let response;
+    for (let i = 0; i <= 10; i++) {
       response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
     }
     console.log(response);
     expect(response.statusCode).toEqual(429);
+  });
+  test('check 202 returned for spamming requests appropriately slowly', async () => {
+    for (let i = 0; i < 10; i++) {
+      await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
+    }
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
+    console.log(response);
+    expect(response.statusCode).toEqual(202);
   });
 
   afterAll(async () => {

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -96,12 +96,15 @@ describe('checkBulkStatus logic', () => {
         expect(JSON.parse(response.text).message).toEqual('Could not find bulk export request with id: INVALID_ID');
       });
   });
-  test('check 429 error returned for spamming requests', async () => {
+  test('check 429 error returned for spamming requests, then 202 after waiting', async () => {
     let response;
     for (let i = 0; i <= 10; i++) {
       response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
     }
     expect(response.statusCode).toEqual(429);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
+    expect(response.statusCode).toEqual(202);
   });
   test('check 202 returned for spamming requests appropriately slowly', async () => {
     for (let i = 0; i < 10; i++) {

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -30,7 +30,7 @@ describe('checkBulkStatus logic', () => {
       .expect(202)
       .then(response => {
         expect(response.headers['x-progress']).toEqual('Exporting files');
-        expect(response.headers['retry-after']).toEqual('120');
+        expect(response.headers['retry-after']).toEqual('1');
       });
   });
   test('check 200 returned for completed request', async () => {

--- a/test/bulkstatus.service.test.js
+++ b/test/bulkstatus.service.test.js
@@ -96,6 +96,14 @@ describe('checkBulkStatus logic', () => {
         expect(JSON.parse(response.text).message).toEqual('Could not find bulk export request with id: INVALID_ID');
       });
   });
+  test('check 429 error returned for spamming requests', async () => {
+    let response = {};
+    for (i = 0; i <= 10; i++) {
+      response = await supertest(app.server).get('/bulkstatus/PENDING_REQUEST');
+    }
+    console.log(response);
+    expect(response.statusCode).toEqual(429);
+  });
 
   afterAll(async () => {
     await cleanUpDb();


### PR DESCRIPTION
# Summary
Updated the retry-after header to be 1 second and implemented 429:TooManyRequests error

## New behavior
- Retry After is reset from 120 -> 1 
- Spamming 10 bulkstatus requests in 1 second results in 429:TooManyRequests error

## Code changes
Above changes and updated testing

# Testing guidance
You probably wont be quick enough to see the 429, so you'll need to make a couple modifications
- Add the following sleep function to line 47 of src/util/exportToNDJson.js:
- ``` await new Promise(resolve => setTimeout(resolve, 20000));```
- This will force the code to sleep for 20 seconds before completing the request
- Now, change the ```RETRY_AFTER``` constant in src/services/bulkstatus.service.js from 1 to 20.
- Fire up the test server with `npm run start`
- Send a `GET` request in Insomnia to `http://localhost:3000/$export`
- Copy the returned `content-location` header and paste it into a new `GET` request
- Ensure to receive `202:Accepted`
- Now spam the send request button and ensure that you eventually receive `429:TooManyRequests`
- Wait the required 20 seconds, then send another bulkstatus request and ensure the job has completed with `200:OK`


