### PR TITLE
Support for group export

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ FHIR Operation to obtain a detailed set of FHIR resources of diverse resource ty
 
 Endpoint: `GET [fhir base]/Patient/$export`
 
+#### All Patients in a Group
+
+FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients that belong to a defined Group resource.
+
+Endpoint: `GET [fhir base]/Group/[id]/$export`
+
 #### System Level Export
 
 Export data from a FHIR server, whether or not it is associated with a patient. This supports use cases like backing up a server, or exporting terminology data by restricting the resources returned using the `_type` parameter.

--- a/src/compartment-definition/patient-references.json
+++ b/src/compartment-definition/patient-references.json
@@ -1,0 +1,234 @@
+{
+  "Account": [
+    "subject"
+  ],
+  "AdverseEvent": [
+    "subject"
+  ],
+  "AllergyIntolerance": [
+    "asserter",
+    "patient",
+    "recorder"
+  ],
+  "Appointment": [
+    "participant.actor"
+  ],
+  "AppointmentResponse": [
+    "actor"
+  ],
+  "AuditEvent": [
+    "agent.who"
+  ],
+  "Basic": [
+    "author",
+    "subject"
+  ],
+  "BodyStructure": [
+    "patient"
+  ],
+  "CarePlan": [
+    "subject",
+    "activity.detail.performer"
+  ],
+  "CareTeam": [
+    "subject",
+    "participant.member"
+  ],
+  "ChargeItem": [
+    "subject"
+  ],
+  "Claim": [
+    "patient",
+    "payee.party"
+  ],
+  "ClaimResponse": [
+    "patient"
+  ],
+  "ClinicalImpression": [
+    "subject"
+  ],
+  "Communication": [
+    "recipient",
+    "sender",
+    "subject"
+  ],
+  "CommunicationRequest": [
+    "recipient",
+    "requester",
+    "sender",
+    "subject"
+  ],
+  "Composition": [
+    "attester.party",
+    "author",
+    "subject"
+  ],
+  "Condition": [
+    "subject",
+    "asserter"
+  ],
+  "Consent": [
+    "patient"
+  ],
+  "Coverage": [
+    "beneficiary",
+    "payor",
+    "policyHolder",
+    "subscriber"
+  ],
+  "CoverageEligibilityRequest": [
+    "patient"
+  ],
+  "CoverageEligibilityResponse": [
+    "patient"
+  ],
+  "DetectedIssue": [
+    "patient"
+  ],
+  "DeviceRequest": [
+    "performer",
+    "subject"
+  ],
+  "DeviceUseStatement": [
+    "subject"
+  ],
+  "DiagnosticReport": [
+    "subject"
+  ],
+  "DocumentManifest": [
+    "author",
+    "recipient",
+    "subject"
+  ],
+  "DocumentReference": [
+    "author",
+    "subject"
+  ],
+  "Encounter": [
+    "subject"
+  ],
+  "EnrollmentRequest": [
+    "candidate"
+  ],
+  "EpisodeOfCare": [
+    "patient"
+  ],
+  "ExplanationOfBenefit": [
+    "patient",
+    "payee.party"
+  ],
+  "FamilyMemberHistory": [
+    "patient"
+  ],
+  "Flag": [
+    "subject"
+  ],
+  "Goal": [
+    "subject"
+  ],
+  "Group": [
+    "member.entity"
+  ],
+  "ImagingStudy": [
+    "subject"
+  ],
+  "Immunization": [
+    "patient"
+  ],
+  "ImmunizationEvaluation": [
+    "patient"
+  ],
+  "ImmunizationRecommendation": [
+    "patient"
+  ],
+  "Invoice": [
+    "subject",
+    "recipient",
+    "subject"
+  ],
+  "List": [
+    "source",
+    "subject"
+  ],
+  "MeasureReport": [
+    "subject"
+  ],
+  "Media": [
+    "subject"
+  ],
+  "MedicationAdministration": [
+    "subject",
+    "performer.actor",
+    "subject"
+  ],
+  "MedicationDispense": [
+    "subject",
+    "receiver",
+    "subject"
+  ],
+  "MedicationRequest": [
+    "subject"
+  ],
+  "MedicationStatement": [
+    "subject"
+  ],
+  "MolecularSequence": [
+    "patient"
+  ],
+  "NutritionOrder": [
+    "patient"
+  ],
+  "Observation": [
+    "performer",
+    "subject"
+  ],
+  "Patient": [
+    "link.other"
+  ],
+  "Person": [
+    "link.target"
+  ],
+  "Procedure": [
+    "subject",
+    "performer.actor"
+  ],
+  "Provenance": [
+    "target"
+  ],
+  "QuestionnaireResponse": [
+    "author",
+    "subject"
+  ],
+  "RelatedPerson": [
+    "patient"
+  ],
+  "RequestGroup": [
+    "action.participant",
+    "subject"
+  ],
+  "ResearchSubject": [
+    "individual"
+  ],
+  "RiskAssessment": [
+    "subject"
+  ],
+  "Schedule": [
+    "actor"
+  ],
+  "ServiceRequest": [
+    "performer",
+    "subject"
+  ],
+  "Specimen": [
+    "subject"
+  ],
+  "SupplyDelivery": [
+    "patient"
+  ],
+  "SupplyRequest": [
+    "deliverTo"
+  ],
+  "VisionPrescription": [
+    "patient"
+  ]
+}

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,6 +1,6 @@
 const fastify = require('fastify');
 
-const { bulkExport, patientBulkExport } = require('../services/export.service');
+const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/export.service');
 const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 
@@ -8,6 +8,7 @@ function build(opts = {}) {
   const app = fastify(opts);
   app.get('/$export', bulkExport);
   app.get('/Patient/$export', patientBulkExport);
+  app.get('/Group/:groupId/$export', groupBulkExport);
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
   return app;

--- a/src/server/exportWorker.js
+++ b/src/server/exportWorker.js
@@ -15,12 +15,12 @@ const exportQueue = new Queue('export', {
 // This handler pulls down the jobs on Redis to handle
 exportQueue.process(async job => {
   // Payload of createJob exists on job.data
-  const { clientEntry, types, typeFilter, systemLevelExport } = job.data;
+  const { clientEntry, types, typeFilter, systemLevelExport, patientIds } = job.data;
   console.log(`export-worker-${process.pid}: Processing Request: ${clientEntry}`);
   await client.connect();
   // Call the existing export ndjson function that writes the files
 
-  const result = await exportToNDJson(clientEntry, types, typeFilter, systemLevelExport);
+  const result = await exportToNDJson(clientEntry, types, typeFilter, systemLevelExport, patientIds);
   if (result) {
     console.log(`export-worker-${process.pid}: Completed Export Request: ${clientEntry}`);
   } else {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -77,6 +77,10 @@ const groupBulkExport = async (request, reply) => {
   if (validateExportParams(request, reply)) {
     request.log.info('Group >>> $export');
     const group = await findResourceById(request.params.groupId, 'Group');
+    if (!group) {
+      reply.code(404).send(new Error(`The requested group ${request.params.groupId} was not found.`));
+      return;
+    }
     const patientIds = group.member.map(m => {
       const splitRef = m.entity.reference.split('/');
       return splitRef[splitRef.length - 1];
@@ -185,7 +189,7 @@ function filterPatientResourceTypes(request, reply) {
   if (types.length !== filteredTypes.length) {
     if (filteredTypes.length === 0) {
       reply.code(400).send(
-        createOperationOutcome('None of the provided resource types are permitted for Patient-level export.', {
+        createOperationOutcome('None of the provided resource types are permitted for Patient/Group export.', {
           issueCode: 400,
           severity: 'error'
         })
@@ -193,7 +197,7 @@ function filterPatientResourceTypes(request, reply) {
     }
     const removedTypes = types.filter(type => !filteredTypes.includes(type));
     request.log.warn(
-      `The following resource types were removed from the request because they are not permitted for Patient-level export: ${removedTypes.join(
+      `The following resource types were removed from the request because they are not permitted for Patient/Group export: ${removedTypes.join(
         ', '
       )}`
     );

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -1,4 +1,4 @@
-const { addPendingBulkExportRequest } = require('../util/mongo.controller');
+const { addPendingBulkExportRequest, findResourceById } = require('../util/mongo.controller');
 const supportedResources = require('../util/supportedResources');
 const exportQueue = require('../resources/exportQueue');
 const patientResourceTypes = require('../compartment-definition/patientExportResourceTypes.json');
@@ -58,6 +58,46 @@ const patientBulkExport = async (request, reply) => {
       types: types,
       typeFilter: request.query._typeFilter,
       systemLevelExport: false
+    };
+    await exportQueue.createJob(job).save();
+    reply
+      .code(202)
+      .header('Content-location', `http://${process.env.HOST}:${process.env.PORT}/bulkstatus/${clientEntry}`)
+      .send();
+  }
+};
+
+/**
+ * Exports data from a FHIR server for resource types pertaining to patients found in the referenced
+ * Group. Uses parsed patient compartment definition similarly to patientBulkExport.
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupBulkExport = async (request, reply) => {
+  if (validateExportParams(request, reply)) {
+    request.log.info('Group >>> $export');
+    const group = await findResourceById(request.params.groupId, 'Group');
+    const patientIds = group.member.map(m => {
+      const splitRef = m.entity.reference.split('/');
+      return splitRef[splitRef.length - 1];
+    });
+
+    const clientEntry = await addPendingBulkExportRequest();
+
+    let types;
+    if (request.query._type) {
+      types = filterPatientResourceTypes(request, reply);
+    } else {
+      types = patientResourceTypes;
+    }
+
+    // Enqueue a new job into Redis for handling
+    const job = {
+      clientEntry: clientEntry,
+      types: types,
+      typeFilter: request.query._typeFilter,
+      systemLevelExport: false,
+      patientIds: patientIds
     };
     await exportQueue.createJob(job).save();
     reply
@@ -161,4 +201,4 @@ function filterPatientResourceTypes(request, reply) {
   return filteredTypes;
 }
 
-module.exports = { bulkExport, patientBulkExport };
+module.exports = { bulkExport, patientBulkExport, groupBulkExport };

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -40,9 +40,10 @@ const findOneResourceWithQuery = async (query, resourceType) => {
   return collection.findOne(query);
 };
 
-const findResourcesWithQuery = async (query, resourceType) => {
+const findResourcesWithQuery = async (query, resourceType, options = {}) => {
   const collection = db.collection(resourceType);
-  return (await collection.find(query)).toArray();
+  const results = collection.find(query, options);
+  return results.toArray();
 };
 
 /**

--- a/test/export.service.test.js
+++ b/test/export.service.test.js
@@ -1,9 +1,12 @@
-const { bulkStatusSetup, cleanUpDb } = require('./populateTestData');
+const { bulkStatusSetup, cleanUpDb, createTestResource } = require('./populateTestData');
 const { db } = require('../src/util/mongo');
 const build = require('../src/server/app');
 const app = build();
 const supertest = require('supertest');
 const queue = require('../src/resources/exportQueue');
+const testPatient = require('./fixtures/testPatient.json');
+const testEncounter = require('./fixtures/testEncounter.json');
+const testGroup = require('./fixtures/testGroup.json');
 
 // Mock export to do nothing
 queue.exportToNDJson = jest.fn();
@@ -83,9 +86,30 @@ describe('Check patient-level export logic (success)', () => {
   afterEach(async () => {
     await cleanUpDb();
   });
+});
 
-  afterAll(async () => {
-    await queue.close();
+describe('Check group-level export logic (success)', () => {
+  beforeEach(async () => {
+    await bulkStatusSetup();
+    await createTestResource(testPatient, 'Patient');
+    await createTestResource(testEncounter, 'Encounter');
+    await createTestResource(testGroup, 'Group');
+    await app.ready();
+  });
+
+  test('check 202 returned and content-location populated', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .get('/Group/testGroup/$export')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
+  afterEach(async () => {
+    await cleanUpDb();
   });
 });
 
@@ -205,4 +229,8 @@ describe('Check patient-level export logic (failure)', () => {
   afterEach(async () => {
     await cleanUpDb();
   });
+});
+
+afterAll(async () => {
+  await queue.close();
 });

--- a/test/export.service.test.js
+++ b/test/export.service.test.js
@@ -200,7 +200,7 @@ describe('Check patient-level export logic (failure)', () => {
       .expect(400)
       .then(response => {
         expect(JSON.parse(response.text).issue[0].details.text).toEqual(
-          'None of the provided resource types are permitted for Patient-level export.'
+          'None of the provided resource types are permitted for Patient/Group export.'
         );
       });
   });

--- a/test/fixtures/testEncounter.json
+++ b/test/fixtures/testEncounter.json
@@ -1,4 +1,7 @@
 {
     "resourceType": "Encounter",
-    "id": "testEncounter"
+    "id": "testEncounter",
+    "subject": {
+      "reference": "Patient/testPatient"
+    }
   }

--- a/test/fixtures/testGroup.json
+++ b/test/fixtures/testGroup.json
@@ -1,0 +1,13 @@
+{
+    "resourceType": "Group",
+    "id": "testGroup",
+    "type": "person",
+    "actual": "true",
+    "member": [
+        {
+            "entity": {
+                "reference": "Patient/testPatient"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Summary
Support for Group export. This is a new endpoint on the server that uses the compartment definition to only export resources that reference patients in the Group submitted.

## New behavior
The [Group export spec](https://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients), shows the new `GET [fhir base]/Group/[id]/$export` endpoint
Note from the spec that "If a FHIR server supports Group-level data export, it SHOULD support reading and searching for Group resource. This enables clients to discover available groups based on stable characteristics such as Group.identifier." ... which uh, I don't think the export server does, but our export server is pretty basic - maybe that's okay?

We can now hit this endpoint in order to export the resources associated with patients in that group (and the patient resources themselves). The [Patient Compartment Definition](https://www.hl7.org/fhir/compartmentdefinition-patient.html)  is used as a mapping for how different resources can reference a patient. The operation then only exports those resources that have a patient reference to one of the patients in the group.

## Code changes

- README and app.js updates for the new `[fhir base]/Group/[id]/$export` route.
- Added `groupBulkExport` function to the export service to handle the new endpoint, identify the patients in the group, and create an export job.
- Updates to the export worker to pass through the group patient Ids.
- Added `patientsQueryForType` function and other updates to `exportToNDJson` file to create and integrate the query object for the patient data filtering based on the group's patient ids.
- Convenience updates to mongo.controller to separate direct db calls out of the `exportToNDJson` file.
- Added tests for the export service and function tests for methods in `exportToNDJson`.
- Added files to capture the compartment definition mapping as well as new testing fixtures.

# Testing guidance
`npm run test`

Add some convenience groups to the server for testing. I added these resources directly using Robo 3T. Example Group resources:
```
{
    "id" : "EXM130-patients",
    "actual" : true,
    "member" : [ 
        {
            "entity" : {
                "reference" : "Patient/denom-EXM130"
            }
        }, 
        {
            "entity" : {
                "reference" : "Patient/numer-EXM130"
            }
        }
    ],
    "resourceType" : "Group",
    "type" : "person"
},
{
    "id" : "empty",
    "actual" : true,
    "member" : [],
    "resourceType" : "Group",
    "type" : "person"
}
```

With the above resources, you can try the endpoint, then use the content-location url returned to view the export resources. 
Request: GET http://localhost:3001/Group/EXM130-patients/$export
Expected Bulkstatus Result: Encounter, Group, Patient, and Procedure resources that reference either denom-EXM130 or numer-EXM130

Request: GET http://localhost:3001/Group/empty/$export?_type=Encounter
Expected Bulkstatus Result: Encounter resources that reference either denom-EXM130 or numer-EXM130

Request: GET http://localhost:3001/Group/empty/$export
Expected Bulkstatus Result: empty output

Feel free to futz around with the groups or filter parameters or add other resources with patient references and try out the endpoint with those.

