### PR TITLE
May 2022 connectathon changes

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -13,8 +13,8 @@ function build(opts = {}) {
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
   app.get('/Group/:groupId', groupSearchById);
-  app.get('/Group/', groupSearch);
-  app.post('/Group/', groupCreate);
+  app.get('/Group', groupSearch);
+  app.post('/Group', groupCreate);
   app.put('/Group/:groupId', groupUpdate);
   return app;
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,6 +3,7 @@ const fastify = require('fastify');
 const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/export.service');
 const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
+const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
 
 function build(opts = {}) {
   const app = fastify(opts);
@@ -11,6 +12,10 @@ function build(opts = {}) {
   app.get('/Group/:groupId/$export', groupBulkExport);
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
+  app.get('/Group/:groupId', groupSearchById);
+  app.get('/Group/', groupSearch);
+  app.post('/Group/', groupCreate);
+  app.put('/Group/:groupId', groupUpdate);
   return app;
 }
 

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -1,0 +1,67 @@
+const {
+  findResourceById,
+  findResourcesWithQuery,
+  createResource,
+  updateResource
+} = require('../util/mongo.controller');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * Result of sending a GET request to [base]/Group/[id].
+ * Searches for a Group resource with the passed in id
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupSearchById = async (request, reply) => {
+  const result = await findResourceById(request.params.groupId, 'Group');
+  if (!result) {
+    reply.code(404).send(new Error(`The requested group ${request.params.groupId} was not found.`));
+  }
+  return result;
+};
+
+/**
+ * Result of sending a GET request to [base]/Group to find all available Groups.
+ * Searches for a Group resource with the passed in id
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupSearch = async (request, reply) => {
+  const result = await findResourcesWithQuery({}, 'Group');
+  if (!result.length > 0) {
+    reply.code(404).send(new Error('No Group resources were found on the server'));
+  }
+  return result;
+};
+
+/**
+ * Creates an object and generates an id for it regardless of the id passed in
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupCreate = async request => {
+  const data = request.body;
+  data['id'] = uuidv4();
+  return createResource(data, 'Group');
+};
+
+/**
+ * Updates the Group resource with the passed in id or creates a new document if
+ * no document with passed id is found
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupUpdate = async (request, reply) => {
+  const data = request.body;
+  if (data.id !== request.params.groupId) {
+    reply.code(300).send(new Error('Argument id must match request body id for PUT request'));
+  }
+  return updateResource(request.params.groupId, data, 'Group');
+};
+
+module.exports = {
+  groupSearchById,
+  groupSearch,
+  groupCreate,
+  groupUpdate
+};

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -39,9 +39,10 @@ const groupSearch = async (request, reply) => {
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
-const groupCreate = async request => {
+const groupCreate = async (request, reply) => {
   const data = request.body;
   data['id'] = uuidv4();
+  reply.code(201);
   return createResource(data, 'Group');
 };
 

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -54,7 +54,7 @@ const groupCreate = async request => {
 const groupUpdate = async (request, reply) => {
   const data = request.body;
   if (data.id !== request.params.groupId) {
-    reply.code(300).send(new Error('Argument id must match request body id for PUT request'));
+    reply.code(400).send(new Error('Argument id must match request body id for PUT request'));
   }
   return updateResource(request.params.groupId, data, 'Group');
 };

--- a/test/fixtures/testGroup.json
+++ b/test/fixtures/testGroup.json
@@ -1,13 +1,13 @@
 {
-    "resourceType": "Group",
-    "id": "testGroup",
-    "type": "person",
-    "actual": "true",
-    "member": [
-        {
-            "entity": {
-                "reference": "Patient/testPatient"
-            }
-        }
-    ]
+  "resourceType": "Group",
+  "id": "testGroup",
+  "type": "person",
+  "actual": true,
+  "member": [
+    {
+      "entity": {
+        "reference": "Patient/testPatient"
+      }
+    }
+  ]
 }

--- a/test/fixtures/updatedTestGroup.json
+++ b/test/fixtures/updatedTestGroup.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Group",
+  "id": "testGroup",
+  "type": "person",
+  "actual": true,
+  "member": [
+    {
+      "entity": {
+        "reference": "Patient/testPatient1"
+      }
+    }
+  ]
+}

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -1,12 +1,12 @@
-const { bulkStatusSetup, cleanUpDb, createTestResource } = require('./populateTestData');
-const build = require('../src/server/app');
+const { bulkStatusSetup, cleanUpDb, createTestResource } = require('../populateTestData');
+const build = require('../../src/server/app');
 const app = build();
 const supertest = require('supertest');
-const testPatient = require('./fixtures/testPatient.json');
+const testPatient = require('../fixtures/testPatient.json');
 const fs = require('fs');
 // import queue to close open handles after tests pass
 // TODO: investigate why queues are leaving open handles in this file
-const queue = require('../src/resources/exportQueue');
+const queue = require('../../src/resources/exportQueue');
 describe('checkBulkStatus logic', () => {
   const clientId = 'testClient';
 

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -1,12 +1,12 @@
-const { bulkStatusSetup, cleanUpDb, createTestResource } = require('./populateTestData');
-const { db } = require('../src/util/mongo');
-const build = require('../src/server/app');
+const { bulkStatusSetup, cleanUpDb, createTestResource } = require('../populateTestData');
+const { db } = require('../../src/util/mongo');
+const build = require('../../src/server/app');
 const app = build();
 const supertest = require('supertest');
-const queue = require('../src/resources/exportQueue');
-const testPatient = require('./fixtures/testPatient.json');
-const testEncounter = require('./fixtures/testEncounter.json');
-const testGroup = require('./fixtures/testGroup.json');
+const queue = require('../../src/resources/exportQueue');
+const testPatient = require('../fixtures/testPatient.json');
+const testEncounter = require('../fixtures/testEncounter.json');
+const testGroup = require('../fixtures/testGroup.json');
 
 // Mock export to do nothing
 queue.exportToNDJson = jest.fn();

--- a/test/services/group.service.test.js
+++ b/test/services/group.service.test.js
@@ -1,0 +1,75 @@
+const build = require('../../src/server/app');
+const app = build();
+const { client } = require('../../src/util/mongo');
+const supertest = require('supertest');
+const { cleanUpDb, createTestResource } = require('../populateTestData');
+const testGroup = require('../fixtures/testGroup.json');
+const updatedTestGroup = require('../fixtures/updatedTestGroup.json');
+// import queue to close open handles after tests pass
+// TODO: investigate why queues are leaving open handles in this file
+const queue = require('../../src/resources/exportQueue');
+
+const TEST_GROUP_ID = 'testGroup';
+const INVALID_GROUP_ID = 'INVALID';
+
+describe('CRUD operations for Group resource', () => {
+  beforeEach(async () => {
+    await client.connect();
+    await app.ready();
+  });
+  test('test create returns 201', async () => {
+    await supertest(app.server).post('/Group').send(testGroup).expect(201);
+  });
+
+  test('test searchById should return 200 when group is in db', async () => {
+    await createTestResource(testGroup, 'Group');
+    await supertest(app.server)
+      .get(`/Group/${TEST_GROUP_ID}`)
+      .expect(200)
+      .then(response => {
+        expect(response.body.id).toEqual(TEST_GROUP_ID);
+      });
+  });
+
+  test('test searchById should return 404 when group is not in db', async () => {
+    await supertest(app.server)
+      .get(`/Group/${INVALID_GROUP_ID}`)
+      .expect(404)
+      .then(response => {
+        expect(JSON.parse(response.text).message).toEqual('The requested group INVALID was not found.');
+      });
+  });
+
+  test('test search should return 200 when groups are in the db', async () => {
+    await createTestResource(testGroup, 'Group');
+    await supertest(app.server)
+      .get(`/Group`)
+      .expect(200)
+      .then(response => {
+        expect(JSON.parse(response.text).length).toEqual(1);
+      });
+  });
+
+  test('test search should return 404 if no groups are in the db', async () => {
+    await supertest(app.server)
+      .get(`/Group`)
+      .expect(404)
+      .then(response => {
+        expect(JSON.parse(response.text).message).toEqual('No Group resources were found on the server');
+      });
+  });
+
+  test('test update returns 200 when group is in db', async () => {
+    await createTestResource(testGroup, 'Group');
+    await supertest(app.server).put(`/Group/${TEST_GROUP_ID}`).send(updatedTestGroup).expect(200);
+  });
+
+  test('test update returns 201 when group is not in db', async () => {
+    await supertest(app.server).put(`/Group/${TEST_GROUP_ID}`).send(updatedTestGroup).expect(200);
+  });
+
+  afterEach(async () => {
+    await cleanUpDb();
+    await queue.close();
+  });
+});

--- a/test/services/ndjson.service.test.js
+++ b/test/services/ndjson.service.test.js
@@ -1,12 +1,12 @@
-const { bulkStatusSetup, cleanUpDb, createTestResourceWithConnect } = require('./populateTestData');
-const { exportToNDJson } = require('../src/util/exportToNDJson');
-const build = require('../src/server/app');
+const { bulkStatusSetup, cleanUpDb, createTestResourceWithConnect } = require('../populateTestData');
+const { exportToNDJson } = require('../../src/util/exportToNDJson');
+const build = require('../../src/server/app');
 const app = build();
 const supertest = require('supertest');
-const testPatient = require('./fixtures/testPatient.json');
+const testPatient = require('../fixtures/testPatient.json');
 // import queue to close open handles after tests pass
 // TODO: investigate why queues are leaving open handles in this file
-const queue = require('../src/resources/exportQueue');
+const queue = require('../../src/resources/exportQueue');
 
 describe('Test ndjson retrieval from specified url', () => {
   const clientId = '123456';

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -1,15 +1,15 @@
-const build = require('../src/server/app');
-const { exportToNDJson, patientsQueryForType, getDocuments } = require('../src/util/exportToNDJson');
-const { cleanUpDb, createTestResourceWithConnect } = require('./populateTestData');
-const testPatient = require('./fixtures/testPatient.json');
-const testEncounter = require('./fixtures/testEncounter.json');
+const build = require('../../src/server/app');
+const { exportToNDJson, patientsQueryForType, getDocuments } = require('../../src/util/exportToNDJson');
+const { cleanUpDb, createTestResourceWithConnect } = require('../populateTestData');
+const testPatient = require('../fixtures/testPatient.json');
+const testEncounter = require('../fixtures/testEncounter.json');
 
-const testServiceRequest = require('./fixtures/testServiceRequest.json');
+const testServiceRequest = require('../fixtures/testServiceRequest.json');
 const app = build();
 const fs = require('fs');
 // import queue to close open handles after tests pass
 // TODO: investigate why queues are leaving open handles in this file
-const queue = require('../src/resources/exportQueue');
+const queue = require('../../src/resources/exportQueue');
 const mockType = ['Patient'];
 
 const expectedFileName = './tmp/123456/Patient.ndjson';


### PR DESCRIPTION
# Summary
Adds Group resource creation to connectathon bundle script. Adds read/search functionality for Group resources.

## New behavior
* Running the connectathon upload script will now create and upload a Group resource for all EXM* patients
* Add read/search functionality for Group resources, as recommended by [the FHIR spec for Group export](https://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients)

## Code changes
* Changes to the `getConnectathonBundles` script to create Group resources for each measure containing all patients for the measure
* Update formatting of test group fixture
* New endpoints to support Group read/search -`GET /Group/[group id]`, `GET /Group`, `POST /Group` and `PUT /Group/[group id]`
* Creation of `group.service.js` to handle all the new Group endpoints 

# Testing guidance
* Run new unit tests for `group.service.js`.
* Try running connectathon script and searching for Groups on the server.
* Try creating Group resources and POSTing/PUTing them to the server.
