### PR TITLE
update DB_HOST and PORT

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
-DB_HOST = localhost
+DB_HOST = 127.0.0.1
 DB_PORT = 27017
 DB_NAME = bulk-export-server
 HOST = localhost
-PORT = 3000
+PORT = 3001
 EXPORT_WORKERS = 2
 REDIS_HOST = localhost
 REDIS_PORT= 6379

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-DB_HOST = localhost
+DB_HOST = 127.0.0.1
 DB_PORT = 27017
 DB_NAME = bulk-export-server-test
 HOST = localhost

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ### Prerequisites
 
-- [Node.js >=11.15.0](https://nodejs.org/en/)
+- [Node.js >=16.11.0](https://nodejs.org/en/)
 - [MongoDB >= 5.0](https://www.mongodb.com)
 - [Git](https://git-scm.com/)
 - [Docker](https://docs.docker.com/get-docker/)
@@ -82,7 +82,7 @@ Debugging with terminal input can be facilitated with `stdin_open: true` and `tt
 
 ## Usage
 
-Once MongoDB is running on your machine, run the `npm start` command to start up the FHIR server at `localhost:3000`. The server can also be run in "watch" mode with `npm run start:watch`.
+Once MongoDB is running on your machine, run the `npm start` command to start up the FHIR server at `localhost:3001`. The server can also be run in "watch" mode with `npm run start:watch`.
 
 For ease of testing, it is recommended to download [Insomnia API Client and Design Tool](https://insomnia.rest) for sending HTTP requests to the server and [Robo 3T](https://robomongo.org) as a GUI for viewing the Mongo database.
 


### PR DESCRIPTION
# Summary

Update issue with mongo connection client introduced with node 17 and thus affecting node updates from 16->18/lts. Also updates port to 3001 since this is typically the port this is run on in testing

## New behavior

Server connects to mongo with node 18

## Code changes
Just environment variable changes in .env to change the database host and the application port

# Testing guidance
`npm run test` and make sure functionality/tests work with node 18
