### PR TITLE
Add bundle upload endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "axios": "^1.3.4",
         "bee-queue": "^1.4.0",
         "dotenv": "^10.0.0",
         "fastify": "^3.22.0",
@@ -1571,6 +1572,29 @@
         "queue-microtask": "^1.1.2"
       }
     },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -2829,6 +2853,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -5177,6 +5220,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -7619,6 +7667,28 @@
         "queue-microtask": "^1.1.2"
       }
     },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -8569,6 +8639,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -10302,6 +10377,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:delete": "node src/scripts/deleteCollections.js",
     "db:reset": "npm run db:delete && npm run db:setup",
     "upload-bundles": "node src/scripts/uploadPremadeBundles.js",
-    "parse-compartment-def": "node src/scripts/parseCompartmentDefinition.js"
+    "parse-compartment-def": "node src/scripts/parseCompartmentDefinition.js",
+    "post-txn-bundles": "node src/scripts/postTransactionBundles.js"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,7 @@
   },
   "homepage": "https://github.com/projecttacoma/bulk-export-server#readme",
   "dependencies": {
+    "axios": "^1.3.4",
     "bee-queue": "^1.4.0",
     "dotenv": "^10.0.0",
     "fastify": "^3.22.0",

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -1,0 +1,37 @@
+const axios = require('axios');
+const path = require('path');
+const fs = require('fs');
+const { createPatientGroupsPerMeasure } = require('../util/groupUtils');
+const mongoUtil = require('../util/mongo');
+
+/**
+ * Uploads all transaction bundles from the specified directory
+ * into the database. Creates a group resource containing
+ * all the patients (with their updated ids that are created
+ * during the transaction bundle upload process) in the process.
+ * Uploads the created group resource to the database.
+ */
+async function main() {
+  const bundlePath = path.resolve(process.argv[2]);
+  const directoryFiles = fs.readdirSync(bundlePath);
+  // store uploaded patientIds to be added as members to FHIR Group
+  const patientRegEx = new RegExp('Patient/[^/]*');
+
+  const patientIdsArray = directoryFiles.map(async file => {
+    const { data } = await axios.post(`http://localhost:3001/`,
+    JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')), {headers: {'Content-Type': 'application/json+fhir'}});
+    
+    const location = data.entry.find(e => e.response.location.startsWith('/Patient'));
+    if (patientRegEx.test(location.response.location)) {
+      return location.response.location.replace('/Patient/', '');
+    }
+  });
+  const patientIds = await Promise.all(patientIdsArray);
+  createPatientGroupsPerMeasure('cms122-10', patientIds);
+  return `Group cms122-10-patients successfully created`;
+}
+
+main()
+  .then(console.log)
+  .catch(console.error)
+  .finally(async () => await mongoUtil.client.close());

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -5,7 +5,7 @@ const { createPatientGroupsPerMeasure } = require('../util/groupUtils');
 const mongoUtil = require('../util/mongo');
 
 // for each group, include the patients that are members of the previous group
-// (ex. creates a group of size 10, a group of size 100, ..., a group of size 20,000)
+// (ex. creates a group of size 10, a group of size 100, ..., a group of size 10,000)
 const GROUP_SIZES = [10, 90, 900, 9000];
 
 /**

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -35,7 +35,7 @@ async function main() {
     // upload practitioner/hospital batch bundles first, if present
     directoryFiles
       .filter(file => file.startsWith('practitioner') || file.startsWith('hospital'))
-      .map(async file => {
+      .forEach(async file => {
         await axios.post(
           `http://${process.env.HOST}:${process.env.PORT}/`,
           JSON.parse(fs.readFileSync(path.join(directoryPath, file), 'utf8')),

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -23,13 +23,17 @@ async function main() {
   console.log('Connected successfully to server');
 
   const bundleDir = path.resolve(process.argv[2]);
+  const measureId = process.argv[3];
+  if (!measureId) {
+    throw new Error('Must supply a measure id to use for specifying the id of the created Group resource');
+  }
 
   const patientRegEx = new RegExp('Patient/[^/]*');
   // store uploaded patientIds to be added as members to FHIR Group (across all patients uploaded so far)
   const allPatientIds = [];
 
   for (const groupSize of GROUP_SIZES) {
-    const directoryPath = path.join(bundleDir, `cms122-${groupSize}-patients`, 'fhir');
+    const directoryPath = path.join(bundleDir, `${measureId}-${groupSize}-patients`, 'fhir');
     const directoryFiles = fs.readdirSync(directoryPath);
 
     // upload practitioner/hospital batch bundles first, if present
@@ -65,9 +69,9 @@ async function main() {
       }
     });
     allPatientIds.push(...patientIds);
-    const success = await createPatientGroupsPerMeasure(`cms122-${allPatientIds.length}`, allPatientIds);
+    const success = await createPatientGroupsPerMeasure(`${measureId}-${allPatientIds.length}`, allPatientIds);
     if (success) {
-      console.log(`Group cms122-${allPatientIds.length}-patients successfully created`);
+      console.log(`Group ${measureId}-${allPatientIds.length}-patients successfully created`);
     } else {
       console.log('Group creation failed');
     }

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const { createPatientGroupsPerMeasure } = require('../util/groupUtils');
 const mongoUtil = require('../util/mongo');
 
+// for each group, include the patients that are members of the previous group
+// (ex. creates a group of size 10, a group of size 100, ..., a group of size 20,000)
+const GROUP_SIZES = [10, 90, 900]; //, 9000, 1000];
+
 /**
  * Uploads all transaction bundles from the specified directory
  * into the database. Creates a group resource containing
@@ -18,44 +22,51 @@ async function main() {
   await mongoUtil.client.connect();
   console.log('Connected successfully to server');
 
-  const bundlePath = path.resolve(process.argv[2]);
-  const groupId = process.argv[3];
-  const directoryFiles = fs.readdirSync(bundlePath);
-  // store uploaded patientIds to be added as members to FHIR Group
+  const bundleDir = path.resolve(process.argv[2]);
+
   const patientRegEx = new RegExp('Patient/[^/]*');
+  // store uploaded patientIds to be added as members to FHIR Group (across all patients uploaded so far)
+  const allPatientIds = [];
 
-  // upload practitioner/hospital batch bundles first, if present
-  directoryFiles
-    .filter(file => file.startsWith('practitioner') || file.startsWith('hospital'))
-    .map(async file => {
-      await axios.post(
-        `http://${process.env.HOST}:${process.env.PORT}/`,
-        JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
-        { headers: { 'Content-Type': 'application/json+fhir' } }
-      );
-    });
+  for (const groupSize of GROUP_SIZES) {
+    const directoryPath = path.join(bundleDir, `cms122-${groupSize}-patients`, 'fhir');
+    const directoryFiles = fs.readdirSync(directoryPath);
 
-  const patientIdsArray = directoryFiles
-    .filter(file => !file.startsWith('practitioner') && !file.startsWith('hospital'))
-    .map(async file => {
-      const { data } = await axios.post(
-        `http://${process.env.HOST}:${process.env.PORT}/`,
-        JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
-        { headers: { 'Content-Type': 'application/json+fhir' } }
-      );
+    // upload practitioner/hospital batch bundles first, if present
+    directoryFiles
+      .filter(file => file.startsWith('practitioner') || file.startsWith('hospital'))
+      .map(async file => {
+        await axios.post(
+          `http://${process.env.HOST}:${process.env.PORT}/`,
+          JSON.parse(fs.readFileSync(path.join(directoryPath, file), 'utf8')),
+          { headers: { 'Content-Type': 'application/json+fhir' } }
+        );
+      });
 
-      const location = data.entry.find(e => e.response.location.startsWith('/Patient'));
-      if (patientRegEx.test(location?.response.location)) {
-        return location.response.location.replace('/Patient/', '');
-      }
-    });
-  const patientIds = await Promise.all(patientIdsArray);
-  const success = await createPatientGroupsPerMeasure(groupId, patientIds);
-  if (success) {
-    return `Group ${groupId}-patients successfully created`;
-  } else {
-    return 'Group creation failed';
+    const patientIdsArray = directoryFiles
+      .filter(file => !file.startsWith('practitioner') && !file.startsWith('hospital'))
+      .map(async file => {
+        const { data } = await axios.post(
+          `http://${process.env.HOST}:${process.env.PORT}/`,
+          JSON.parse(fs.readFileSync(path.join(directoryPath, file), 'utf8')),
+          { headers: { 'Content-Type': 'application/json+fhir' } }
+        );
+
+        const location = data.entry.find(e => e.response.location.startsWith('/Patient'));
+        if (patientRegEx.test(location?.response.location)) {
+          return location.response.location.replace('/Patient/', '');
+        }
+      });
+    const patientIds = await Promise.all(patientIdsArray);
+    allPatientIds.push(...patientIds);
+    const success = await createPatientGroupsPerMeasure(allPatientIds.length, allPatientIds);
+    if (success) {
+      console.log(`Group cms122-${allPatientIds.length}-patients successfully created`);
+    } else {
+      console.log('Group creation failed');
+    }
   }
+  return 'Group upload finished';
 }
 
 main()

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -21,26 +21,30 @@ async function main() {
   // store uploaded patientIds to be added as members to FHIR Group
   const patientRegEx = new RegExp('Patient/[^/]*');
 
-  directoryFiles.filter(file => file.startsWith('practitioner') || file.startsWith('hospital')).map(async file => {
-    await axios.post(
-      `http://${process.env.HOST}:${process.env.PORT}/`,
-      JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
-      { headers: { 'Content-Type': 'application/json+fhir' } }
-    );
-  });
+  directoryFiles
+    .filter(file => file.startsWith('practitioner') || file.startsWith('hospital'))
+    .map(async file => {
+      await axios.post(
+        `http://${process.env.HOST}:${process.env.PORT}/`,
+        JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
+        { headers: { 'Content-Type': 'application/json+fhir' } }
+      );
+    });
 
-  const patientIdsArray = directoryFiles.filter(file => !file.startsWith('practitioner') && !file.startsWith('hospital')).map(async file => {
-    const { data } = await axios.post(
-      `http://${process.env.HOST}:${process.env.PORT}/`,
-      JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
-      { headers: { 'Content-Type': 'application/json+fhir' } }
-    );
+  const patientIdsArray = directoryFiles
+    .filter(file => !file.startsWith('practitioner') && !file.startsWith('hospital'))
+    .map(async file => {
+      const { data } = await axios.post(
+        `http://${process.env.HOST}:${process.env.PORT}/`,
+        JSON.parse(fs.readFileSync(path.join(bundlePath, file), 'utf8')),
+        { headers: { 'Content-Type': 'application/json+fhir' } }
+      );
 
-    const location = data.entry.find(e => e.response.location.startsWith('/Patient'));
-    if (patientRegEx.test(location?.response.location)) {
-      return location.response.location.replace('/Patient/', '');
-    }
-  });
+      const location = data.entry.find(e => e.response.location.startsWith('/Patient'));
+      if (patientRegEx.test(location?.response.location)) {
+        return location.response.location.replace('/Patient/', '');
+      }
+    });
   const patientIds = await Promise.all(patientIdsArray);
   const success = await createPatientGroupsPerMeasure(groupId, patientIds);
   if (success) {

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -44,6 +44,8 @@ async function main() {
       });
 
     const patientFiles = directoryFiles.filter(
+      // filter out practitioner/hospital batch bundles and group resource, if present
+      // (the group resource will have outdated patient references)
       file => !file.startsWith('practitioner') && !file.startsWith('hospital') && !file.startsWith('group')
     );
     const promises = [];

--- a/src/scripts/postTransactionBundles.js
+++ b/src/scripts/postTransactionBundles.js
@@ -10,6 +10,9 @@ const mongoUtil = require('../util/mongo');
  * all the patients (with their updated ids that are created
  * during the transaction bundle upload process) in the process.
  * Uploads the created group resource to the database.
+ *
+ * Note: Synthea creates batch bundles for hospital/practitioner info, which
+ * should be POSTed before POSTing the transaction bundles that refer to patients.
  */
 async function main() {
   await mongoUtil.client.connect();
@@ -21,6 +24,7 @@ async function main() {
   // store uploaded patientIds to be added as members to FHIR Group
   const patientRegEx = new RegExp('Patient/[^/]*');
 
+  // upload practitioner/hospital batch bundles first, if present
   directoryFiles
     .filter(file => file.startsWith('practitioner') || file.startsWith('hospital'))
     .map(async file => {

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -53,8 +53,6 @@ const getBundleFiles = (directory, searchPattern) => {
   });
 };
 
-
-
 /**
  * Uploads all the resources from the specified directory into the
  * database.

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const mongoUtil = require('../util/mongo');
 const { createResource } = require('../util/mongo.controller');
+const { createPatientGroupsPerMeasure } = require('../util/groupUtils');
 
 const ecqmContentR4Path = path.resolve(path.join(__dirname, '../../ecqm-content-r4-2021/bundles/measure/'));
 
@@ -52,36 +53,7 @@ const getBundleFiles = (directory, searchPattern) => {
   });
 };
 
-/**
- * Creates a FHIR Group resource that represents the Patients associated with a given Measure
- * and adds it to the database
- * @param {String} measureId An id for the associated FHIR Measure to be used in the Group Id
- * @param {Array} patientIds An array of FHIR Patient ids to be added as Group members
- * @returns {Boolean} True if the Group creation succeeds, false otherwise
- */
-async function createPatientGroupsPerMeasure(measureId, patientIds) {
-  const group = {
-    resourceType: 'Group',
-    id: `${measureId}-patients`,
-    type: 'person',
-    actual: true,
-    member: patientIds.map(pid => ({
-      entity: {
-        reference: `Patient/${pid}`
-      }
-    }))
-  };
 
-  try {
-    await createResource(group, 'Group');
-    return true;
-  } catch (e) {
-    if (e.code !== 11000) {
-      console.log(e.message);
-    }
-    return false;
-  }
-}
 
 /**
  * Uploads all the resources from the specified directory into the

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,9 +4,11 @@ const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/
 const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
+const { uploadTransactionBundle } = require('../services/bundle.service');
 
-function build(opts = {}) {
-  const app = fastify(opts);
+// set bodyLimit to 50mb
+function build(opts) {
+  const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
   app.get('/$export', bulkExport);
   app.get('/Patient/$export', patientBulkExport);
   app.get('/Group/:groupId/$export', groupBulkExport);
@@ -16,6 +18,7 @@ function build(opts = {}) {
   app.get('/Group', groupSearch);
   app.post('/Group', groupCreate);
   app.put('/Group/:groupId', groupUpdate);
+  app.post('/', uploadTransactionBundle);
   return app;
 }
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,7 +4,7 @@ const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/
 const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
-const { uploadTransactionBundle } = require('../services/bundle.service');
+const { uploadTransactionOrBatchBundle } = require('../services/bundle.service');
 
 // set bodyLimit to 50mb
 function build(opts) {
@@ -18,7 +18,7 @@ function build(opts) {
   app.get('/Group', groupSearch);
   app.post('/Group', groupCreate);
   app.put('/Group/:groupId', groupUpdate);
-  app.post('/', uploadTransactionBundle);
+  app.post('/', uploadTransactionOrBatchBundle);
   return app;
 }
 

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -1,0 +1,130 @@
+const { v4: uuidv4 } = require('uuid');
+const { replaceReferences } = require('../util/bundleUtils');
+const { createResource, updateResource } = require('../util/mongo.controller');
+
+/**
+ * Creates transaction-response bundle.
+ * Each entry elements SHALL contain a 'response' element which
+ * indicates the outcome of the HTTP operation.
+ * @param {Array} requestResults array of request result objects
+ * @param {Object} reply the response object
+ *
+ * @returns {Object} transaction-response bundle
+ */
+const createTransactionResponseBundle = (requestResults, reply) => {
+  const bundle = {
+    resourceType: 'Bundle',
+    type: 'transaction-response',
+    id: uuidv4()
+  };
+
+  bundle.link = [
+    {
+      url: `${reply.request.protocol}://${reply.request.hostname}`,
+      relation: 'self'
+    }
+  ];
+
+  const entries = [];
+  requestResults.forEach(result => {
+    const entry = {
+      response: {
+        status: `${result.status} ${result.statusText}`
+      }
+    };
+    if (result.status === 200 || result.status === 201) {
+      entry.response.location = `/${result.resource.resourceType}/${result.resource.id}`;
+    } else {
+      entry.response.outcome = result.data;
+    }
+    entries.push(entry);
+  });
+
+  bundle.entry = entries;
+  return bundle;
+};
+
+/**
+ * Uploads transaction bundle to server.
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ *
+ * @returns {Object} transaction-response bundle
+ */
+const uploadTransactionBundle = async (request, reply) => {
+  request.log.info('Base >>> Transaction Bundle Upload');
+  const { resourceType, type, entry: entries } = request.body;
+
+  if (resourceType !== 'Bundle') {
+    reply.code(400).send(new Error(`Expected 'resourceType: Bundle', but received 'resourceType: ${resourceType}'.`));
+  }
+  if (type.toLowerCase() !== 'transaction') {
+    reply.code(400).send(new Error(`Expected 'type: transaction'. Received 'type: ${type}'.`));
+  }
+
+  const requestResults = await uploadResourcesFromBundle(entries);
+  const bundle = createTransactionResponseBundle(requestResults, reply);
+  request.log.info('Transaction bundle successfully uploaded to server');
+  return bundle;
+};
+
+/**
+ * Scrubs transaction bundle entries and uploads each entry to the server.
+ * @param {Array} entries entries from POSTed transaction bundle
+ * @returns array of request results
+ */
+const uploadResourcesFromBundle = async entries => {
+  const scrubbedEntries = replaceReferences(entries);
+  const requestsArray = scrubbedEntries.map(async entry => {
+    const { method } = entry.request;
+    return insertBundleResources(entry, method).catch(e => {
+      const results = {
+        resourceType: 'OperationOutcome',
+        issue: e.issue,
+        statusCode: e.statusCode
+      };
+      return {
+        status: e.statusCode,
+        statusCode: e.statusCode,
+        statusText: e.issue[0].code,
+        data: results.toJSON()
+      };
+    });
+  });
+  const requestResults = await Promise.all(requestsArray);
+  return requestResults;
+};
+
+/**
+ * Inserts/Updates the bundle entry as a document in mongo
+ * @param {Object} entry entry object from POSTed transaction bundle
+ * @param {string} method method of the HTTP request (POST/PUT)
+ * @returns results of mongo insertion or update
+ */
+const insertBundleResources = async (entry, method) => {
+  if (method === 'POST') {
+    entry.resource.id = uuidv4();
+    const { id } = await createResource(entry.resource, entry.resource.resourceType);
+    if (id != null) {
+      entry.status = 201;
+      entry.statusText = 'Created';
+    }
+  }
+  if (method === 'PUT') {
+    const { id, created } = await updateResource(entry.resource.id, entry.resource, entry.resource.resourceType);
+    if (created === true) {
+      entry.status = 201;
+      entry.statusText = 'Created';
+    } else if (id != null && created === false) {
+      entry.status = 200;
+      entry.statusText = 'OK';
+    }
+  } else {
+    throw new Error(
+      `Expected requests of type PUT or POST, received ${method} for ${entry.resource.resourceType}/${entry.resource.id}`
+    );
+  }
+  return entry;
+};
+
+module.exports = { uploadTransactionBundle };

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -89,8 +89,7 @@ const uploadResourcesFromBundle = async (type, entries, reply) => {
       }
     });
   });
-  const requestResults = await Promise.all(requestsArray);
-  return requestResults;
+  return Promise.all(requestsArray);
 };
 
 /**

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -4,7 +4,7 @@ const { createResource, updateResource } = require('../util/mongo.controller');
 
 /**
  * Creates transaction-response or batch-response bundle.
- * Each entry elements SHALL contain a 'response' element which
+ * Each entry element SHALL contain a 'response' element which
  * indicates the outcome of the HTTP operation.
  * @param {Array} requestResults array of request result objects
  * @param {Object} reply the response object

--- a/src/services/bundle.service.js
+++ b/src/services/bundle.service.js
@@ -8,8 +8,7 @@ const { createResource, updateResource } = require('../util/mongo.controller');
  * indicates the outcome of the HTTP operation.
  * @param {Array} requestResults array of request result objects
  * @param {Object} reply the response object
- * @param {type} type bundle type (must be 'transaction' or 'batch')
- *
+ * @param {string} type bundle type (must be 'transaction' or 'batch')
  * @returns {Object} transaction-response/batch-response bundle
  */
 const createResponseBundle = (requestResults, reply, type) => {
@@ -49,7 +48,6 @@ const createResponseBundle = (requestResults, reply, type) => {
  * Uploads bundle to server.
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
- *
  * @returns {Object} transaction-response/batch-response bundle
  */
 const uploadTransactionOrBatchBundle = async (request, reply) => {

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require('uuid');
 
 /**
- * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference
+ * For entries in a transaction/batch bundle whose IDs will be auto-generated, replace all instances of an existing reference
  * to the old id with a reference to the newly generated one.
  *
  * Modify the request type to PUT after forcing the IDs. This will not affect return results, just internal representation

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -1,0 +1,53 @@
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * For entries in a transaction bundle whose IDs will be auto-generated, replace all instances of an existing reference
+ * to the old id with a reference to the newly generated one.
+ *
+ * Modify the request type to PUT after forcing the IDs. This will not affect return results, just internal representation
+ *
+ * @param {Array} entries bundle entries
+ * @returns array of entries with replaced references
+ */
+const replaceReferences = entries => {
+  entries.forEach(e => {
+    if (e.request.method === 'POST') {
+      e.isPost = true;
+      e.oldId = e.resource.id;
+      e.newId = uuidv4();
+    }
+  });
+
+  let entriesStr = JSON.stringify(entries);
+  const postEntries = entries.filter(e => e.isPost);
+
+  // For each POST entry, replace existing reference across all entries
+  postEntries.forEach(e => {
+    // Checking fullUrl and id in separate replace loops will prevent invalid ResourceType/ResourceID -> urn:uuid references
+    if (e.oldId) {
+      const idRegexp = new RegExp(`${e.resource.resourceType}/${e.oldId}`, 'g');
+      entriesStr = entriesStr.replace(idRegexp, `${e.resource.resourceType}/${e.newId}`);
+    }
+    if (e.fullUrl) {
+      const urnRegexp = new RegExp(e.fullUrl, 'g');
+      entriesStr = entriesStr.replace(urnRegexp, `${e.resource.resourceType}/${e.newId}`);
+    }
+  });
+
+  // Remove metadata and modify request type/resource id
+  const newEntries = JSON.parse(entriesStr).map(e => {
+    if (e.isPost) {
+      e.resource.id = e.newId;
+      e.request = {
+        method: 'PUT',
+        url: `${e.resource.resourceType}/${e.newId}`
+      };
+    }
+
+    return { resource: e.resource, request: e.request };
+  });
+
+  return newEntries;
+};
+
+module.exports = { replaceReferences };

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -31,4 +31,4 @@ async function createPatientGroupsPerMeasure(measureId, patientIds) {
   }
 }
 
-module.exports = { createPatientGroupsPerMeasure }
+module.exports = { createPatientGroupsPerMeasure };

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -1,0 +1,34 @@
+const { createResource } = require('./mongo.controller');
+
+/**
+ * Creates a FHIR Group resource that represents the Patients associated with a given Measure
+ * and adds it to the database
+ * @param {String} measureId An id for the associated FHIR Measure to be used in the Group Id
+ * @param {Array} patientIds An array of FHIR Patient ids to be added as Group members
+ * @returns {Boolean} True if the Group creation succeeds, false otherwise
+ */
+async function createPatientGroupsPerMeasure(measureId, patientIds) {
+  const group = {
+    resourceType: 'Group',
+    id: `${measureId}-patients`,
+    type: 'person',
+    actual: true,
+    member: patientIds.map(pid => ({
+      entity: {
+        reference: `Patient/${pid}`
+      }
+    }))
+  };
+
+  try {
+    await createResource(group, 'Group');
+    return true;
+  } catch (e) {
+    if (e.code !== 11000) {
+      console.log(e.message);
+    }
+    return false;
+  }
+}
+
+module.exports = { createPatientGroupsPerMeasure }

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -3,7 +3,7 @@ const { createResource } = require('./mongo.controller');
 /**
  * Creates a FHIR Group resource that represents the Patients associated with a given Measure
  * and adds it to the database
- * @param {String} measureId An id for the associated FHIR Measure to be used in the Group Id
+ * @param {string} measureId An id for the associated FHIR Measure to be used in the Group Id
  * @param {Array} patientIds An array of FHIR Patient ids to be added as Group members
  * @returns {Boolean} True if the Group creation succeeds, false otherwise
  */

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -19,7 +19,6 @@ async function createPatientGroupsPerMeasure(measureId, patientIds) {
       }
     }))
   };
-
   try {
     await createResource(group, 'Group');
     return true;


### PR DESCRIPTION
# Summary
Exposes new endpoint for POSTing transaction and batch bundles to the server. Creates script for POSTing a series of bundles in a directory.

## Motivation
When uploading transaction/batch bundles to the server, we are interested in replacing the references with new ids, which does not happen when we use the current `uploadPremadeBundles` script. Also, for small test cases where we want to upload a single transaction bundle and check export functionality with it, we want to have an easier means to upload this bundle via an endpoint.

This functionality will be used in a larger workflow that does the following:
1. Several groups of patients of different sizes are generated in Synthea, and each set of patient data is represented as a separate transaction bundle. Additionally, as outlined in the [Synthea wiki](https://github.com/synthetichealth/synthea/wiki/FHIR-Transaction-Bundles), batch bundles get created for the Practitioner resources (`output/fhir/practitionerinformation…json`) and the Organization and Location resources (`output/fhir/hospitalinformation…json`). 
2. The batch bundles for hospital and practitioner info are uploaded to the server.
3. The transaction bundles are uploaded to the server, and a Group resource is created for each group of patients using the new ids that are generated during the transaction bundle upload process.
4. The groups are used to conduct group `$export` requests from a bulk export client.

## New behavior
A user can POST a transaction of batch bundle to `http://localhost:3001/` Note the difference between batch and transaction bundles: if there is an issue with uploading the transaction bundle (i.e. one operation fails), then everything fails. With a batch bundle, if one operation fails, the rest of the operations can still be completed. See ["Batch Processing Rules"](https://www.hl7.org/fhir/http.html#brules) for more information.

## Code changes
* New endpoint in `src/server/app.js` for bundle upload
* New service `src/services/bundle.service.js` for uploading the bundle, replacing the references in the bundle, and sending back a transaction-response/batch-response bundle.
* New util file `src/util/bundleUtils.js` for replacing references (logic ported over from deqm-test-server)
* Moved `createPatientGroupsPerMeasure` so it can be used between multiple scripts
* New script `postTransactionBundles.js`
    * Based on this [ruby script in the inferno reference server](https://github.com/bulk-dqm/inferno-reference-server/blob/cms-122/upload_cms.rb)
    * After writing this script, I realized it’s pretty similar to the `uploadPremadeBundles` script. Open to feedback on whether it’s okay to keep this script or try to port over more logic from the existing script. For my given use case (uploading Synthea data), I would like to create groups for a given Synthea run rather than for a specific FHIR measure, and I would like to upload the practitioner/hospital batch bundles before uploading the transaction bundles for the rest of the patients. Also, I would like to use the updated ids that come with POSTing transaction bundles. This logic does not appear in the other script.

# Testing guidance
For all tests, use the following endpoint: `http://localhost:3001/`.
* POST a transaction bundle to the server and check for 200 OK response with a `transaction-response` resource
* POST a batch bundle to the server and check for 200 OK response with a `batch-response` resource
* POST a bundle with a different type (or POST a non-bundle resource) and check that an error is thrown
* POST a transaction bundle that throws an error (ex. One of the `request`s in the bundle is not of type POST or PUT) and check that an error is thrown
* Do the same for a batch bundle and check that no error is thrown, but that the problematic resource’s location is not included as an `entity` in the `batch-response` bundle that is returned. It should have a `response.outcome` instead
* If you want to test things end-to-end, create a directory of transaction bundles (ex. from synthea or elsewhere), run the script `npm run post-txn-bundles <bundle directory path> <group Id (will have “patients” appended to it after group creation)>`. Afterwards, take the group Id that is logged to the console and run a group `$export` on it. (So far tested with groups of up to 1000 patients)