### PR TITLE
Update ValueSet code extraction

### DIFF
--- a/src/util/valueSetHelper.js
+++ b/src/util/valueSetHelper.js
@@ -3,20 +3,21 @@
  * @param valueSetResources FHIR ValueSets.
  * @returns an array of the codes in the valueSet
  */
-function getHierarchicalCodes(valueSet) {
+function getHierarchicalCodes(valueSetResources) {
   const codes = [];
-  if (!valueSet.abstract && !valueSet.inactive && valueSet.code && valueSet.system) {
-    codes.push({
-      code: valueSet.code,
-      system: valueSet.system,
-      version: valueSet.version,
-      display: valueSet.display
-    });
-  }
-  if (valueSet.contains && valueSet.contains.length > 0) {
-    codes.push(...getHierarchicalCodes(valueSet.contains));
-  }
-
+  valueSetResources.forEach(valueSet => {
+    if (!valueSet.abstract && !valueSet.inactive && valueSet.code && valueSet.system) {
+      codes.push({
+        code: valueSet.code,
+        system: valueSet.system,
+        version: valueSet.version,
+        display: valueSet.display
+      });
+    }
+    if (valueSet.contains && valueSet.contains.length > 0) {
+      codes.push(...getHierarchicalCodes(valueSet.contains));
+    }
+  });
   return codes;
 }
 /**


### PR DESCRIPTION
# Summary
Fixes bug where the code assumes a single object exists in `ValueSet.expansion.contains`, when it is possible for multiple elements to exist.

TLDR: if this server was built in TypeScript we would not have this bug

## New behavior
The cardinality of [ValueSet.expansion.contains](https://build.fhir.org/valueset-definitions.html#ValueSet.expansion.contains) is `0..*`, meaning that multiple codes can be contained in the value set expansion. Currently, the main branch assumes a cardinality of `0..1`, causing a 500 error to be returned from the server (because it cannot extract the codes properly).

With this fix, the server now loops over all codes contained in `ValueSet.expansions.contains` when parsing a `_typeFilter` query involving `ValueSet` subqueries. The server should thus return a 200 status code (i.e. have a successful export when `_typeFilter` is specified by the client).

## Code changes
Updates `getHierarchicalCodes` to loop over each code, since there can be multiple. (The variable names here are not the most indicative of what they actually represent… feel free to leave suggestions on changes to the var names if I don’t have a chance to get to it before this undergoes review)

# Testing guidance
Run an export request in Insomnia, with the `_typeFilter` query populated.

An example request will look something like this (assuming you are running the server on localhost:3001):

```
GET http://localhost:3001/$export?_typeFilter=<typefilter query>
```
The `_typeFilter` query should be of the form `<resourceType>?<property>=<value>`.

Expected result: 200 status is returned, and `Content-Location` header is populated with a url to follow that redirects to the bulk status. Sending a GET request to that url should return URLs containing the ndjson content.

