### PR TITLE
Add support for "patient" parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
-        mongodb-version: ['5.0']
+        node-version: [18.x]
+        mongodb-version: ['7.x']
 
     steps:
       - uses: actions/checkout@v2
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
-        mongodb-version: ['5.0']
+        node-version: [18.x]
+        mongodb-version: ['7.x']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
         with:
           redis-version: ${{ matrix.redis-version }}
 
+      - name: Setup Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build --if-present
+
       - name: Run Jest Coverage Report
         uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        mongodb-version: ['7.x']
+        mongodb-version: ['7.0']
 
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        mongodb-version: ['7.x']
+        mongodb-version: ['7.0']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,9 @@ jobs:
         with:
           redis-version: ${{ matrix.redis-version }}
 
-      - name: Setup Dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build --if-present
-
       - name: Run Jest Coverage Report
         uses: artiomtr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           threshold: 60
+          test-script: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: npm run build --if-present
 
       - name: Run Jest Coverage Report
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.4
+        uses: artiomtr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           threshold: 60

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ FHIR Operation to obtain a detailed set of FHIR resources of diverse resource ty
 
 Endpoint: `GET [fhir base]/Patient/$export`
 
-Alternatively, a POST request (`POST [fhir base]/Patient/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
+Alternatively, a POST request (`POST [fhir base]/Patient/$export`) can be sent. The export parameters must be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
 
 #### All Patients in a Group
 
@@ -114,7 +114,7 @@ FHIR Operation to obtain a detailed set of FHIR resources of diverse resource ty
 
 Endpoint: `GET [fhir base]/Group/[id]/$export`
 
-Alternatively, a POST request (`POST [fhir base]/Group/[id]/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
+Alternatively, a POST request (`POST [fhir base]/Group/[id]/$export`) can be sent. The export parameters must be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
 
 #### System Level Export
 
@@ -122,7 +122,7 @@ Export data from a FHIR server, whether or not it is associated with a patient. 
 
 Endpoint: `GET [fhir base]/$export`
 
-Alternatively, a POST request (`POST [fhir base]/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
+Alternatively, a POST request (`POST [fhir base]/$export`) can be sent. The export parameters must be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
 
 For more information on the export endpoints, read this documentation on the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
 

--- a/README.md
+++ b/README.md
@@ -106,17 +106,23 @@ FHIR Operation to obtain a detailed set of FHIR resources of diverse resource ty
 
 Endpoint: `GET [fhir base]/Patient/$export`
 
+Alternatively, a POST request (`POST [fhir base]/Patient/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
+
 #### All Patients in a Group
 
 FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients that belong to a defined Group resource.
 
 Endpoint: `GET [fhir base]/Group/[id]/$export`
 
+Alternatively, a POST request (`POST [fhir base]/Group/[id]/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
+
 #### System Level Export
 
 Export data from a FHIR server, whether or not it is associated with a patient. This supports use cases like backing up a server, or exporting terminology data by restricting the resources returned using the `_type` parameter.
 
 Endpoint: `GET [fhir base]/$export`
+
+Alternatively, a POST request (`POST [fhir base]/$export`) can be sent. The export parameters should be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
 
 For more information on the export endpoints, read this documentation on the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The server supports the following query parameters:
   - For Patient- and Group-level requests, the [Patient Compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html) is used as a point of reference for filtering the resource types that are returned.
 - `_outputFormat`: The server supports the following formats: `application/fhir+ndjson`, `application/ndjson+fhir`, `application/ndjson`, `ndjson`
 - `_typeFilter`: Filters the response to only include resources that meet the criteria of the specified comma-delimited FHIR REST queries. Returns an error for queries specified by the client that are unsupported by the server. Supports queries on the ValueSets (`type:in`, `code:in`, etc.) of a given resource type.
+- `patient`: Only applicable to POST requests for group-level and patient-level requests. When provided, the server SHALL NOT return resources in the patient compartment definition belonging to patients outside the list. Can support multiple patient references in a single request.
 
 ## License
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -10,8 +10,11 @@ const { uploadTransactionOrBatchBundle } = require('../services/bundle.service')
 function build(opts) {
   const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
   app.get('/$export', bulkExport);
+  app.post('/$export', bulkExport);
   app.get('/Patient/$export', patientBulkExport);
+  app.post('/Patient/$export', patientBulkExport);
   app.get('/Group/:groupId/$export', groupBulkExport);
+  app.post('/Group/:groupId/$export', groupBulkExport);
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
   app.get('/Group/:groupId', groupSearchById);

--- a/src/server/exportWorker.js
+++ b/src/server/exportWorker.js
@@ -15,12 +15,12 @@ const exportQueue = new Queue('export', {
 // This handler pulls down the jobs on Redis to handle
 exportQueue.process(async job => {
   // Payload of createJob exists on job.data
-  const { clientEntry, types, typeFilter, systemLevelExport, patientIds } = job.data;
+  const { clientEntry, types, typeFilter, patient, systemLevelExport, patientIds } = job.data;
   console.log(`export-worker-${process.pid}: Processing Request: ${clientEntry}`);
   await client.connect();
   // Call the existing export ndjson function that writes the files
 
-  const result = await exportToNDJson(clientEntry, types, typeFilter, systemLevelExport, patientIds);
+  const result = await exportToNDJson(clientEntry, types, typeFilter, patient, systemLevelExport, patientIds);
   if (result) {
     console.log(`export-worker-${process.pid}: Completed Export Request: ${clientEntry}`);
   } else {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -77,7 +77,8 @@ const patientBulkExport = async (request, reply) => {
     const job = {
       clientEntry: clientEntry,
       types: types,
-      typeFilter: request.query._typeFilter,
+      typeFilter: parameters._typeFilter,
+      patient: parameters.patient,
       systemLevelExport: false
     };
     await exportQueue.createJob(job).save();
@@ -131,7 +132,8 @@ const groupBulkExport = async (request, reply) => {
     const job = {
       clientEntry: clientEntry,
       types: types,
-      typeFilter: request.query._typeFilter,
+      typeFilter: parameters._typeFilter,
+      patient: parameters.patient,
       systemLevelExport: false,
       patientIds: patientIds
     };

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -334,7 +334,6 @@ function filterPatientResourceTypes(request, reply, types) {
  * @param {Object} reply the response object
  */
 async function validatePatientReferences(patientParam, reply) {
-  console.log(patientParam);
 
   const unknownPatientPromises = patientParam.map(async p => {
     const splitRef = p.reference.split('/');

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -272,7 +272,10 @@ const gatherParams = (query, body) => {
     body.parameter.reduce((acc, e) => {
       if (!e.resource) {
         if (!acc[e.name]) {
-          // For now, all usable params are expected to be stored under one of these four keys
+          if (acc[e.name] === 'patient') {
+            acc[e.name] = [e.valueReference];
+          }
+          // For now, all usable params are expected to be stored under one of these fives keys
           acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode || e.valueReference;
         } else {
           // store an array as the value since multiple values map to the parameter

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -46,10 +46,11 @@ const buildSearchParamList = resourceType => {
  * @param {string} clientId  an id to add to the file name so the client making the request can be tracked
  * @param {Array} types Array of types to be queried for, retrieved from request params
  * @param {string} typeFilter String of comma separated FHIR REST search queries
+ * @param {string | Array} patient Patient references from the "patient" param, used to filter results
  * @param {boolean} systemLevelExport boolean flag from job that signals whether request is for system-level export (determines filtering)
  * @param {Array} patientIds Array of patient ids for patients relevant to this export (undefined if all patients)
  */
-const exportToNDJson = async (clientId, types, typeFilter, systemLevelExport, patientIds) => {
+const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelExport, patientIds) => {
   try {
     const dirpath = './tmp/';
     fs.mkdirSync(dirpath, { recursive: true });

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -119,7 +119,7 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
     // if 'patient' parameter is present, apply additional filtering on the resources related to these patients
     // strip off '.reference' to align with the format of the patientIds array
     const patientParamIds = patient.map(p => {
-      const splitRef = p.entity.reference.split('/');
+      const splitRef = p.reference.split('/');
       return splitRef[splitRef.length - 1];
     });
 

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -115,12 +115,20 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
       });
     }
     const exportTypes = systemLevelExport ? requestTypes.filter(t => t !== 'ValueSet') : requestTypes;
+
+    // if 'patient' parameter is present, apply additional filtering on the resources related to these patients
+    // strip off '.reference' to align with the format of the patientIds array
+    const patientParamIds = patient.map(p => {
+      const splitRef = p.entity.reference.split('/');
+      return splitRef[splitRef.length - 1];
+    });
+
     let docs = exportTypes.map(async collectionName => {
       return getDocuments(
         collectionName,
         searchParameterQueries[collectionName],
         valueSetQueries[collectionName],
-        patientIds
+        patientParamIds || patientIds
       );
     });
     docs = await Promise.all(docs);

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -118,7 +118,7 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
 
     // if 'patient' parameter is present, apply additional filtering on the resources related to these patients
     // strip off '.reference' to align with the format of the patientIds array
-    const patientParamIds = patient.map(p => {
+    const patientParamIds = patient?.map(p => {
       const splitRef = p.reference.split('/');
       return splitRef[splitRef.length - 1];
     });

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -35,7 +35,7 @@ async function createPatientGroupsPerMeasure(measureId, patientIds) {
  * Verifies that all patients specified in the "patient" parameter are members of the group, for a
  * given group export. Throws a 404 error wrapped in an OperationOutcome if any patients are specified
  * that do *not* belong to the group.
- * @param {Object} patientParam object containing array of patient references
+ * @param {Array} patientParam array of patient references
  * @param {Object} group FHIR Group resource
  * @param {Object} reply the response object
  */

--- a/src/util/valueSetHelper.js
+++ b/src/util/valueSetHelper.js
@@ -53,4 +53,4 @@ function getCodesFromValueSet(valueSet) {
   }
   return codes;
 }
-module.exports = { getCodesFromValueSet };
+module.exports = { getHierarchicalCodes, getCodesFromValueSet };

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -377,6 +377,28 @@ describe('Check patient-level export logic (failure)', () => {
       });
   });
 
+  test('throws 404 when patient param is supplied with a patient that is not on the server', async () => {
+    await supertest(app.server)
+      .post('/Patient/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'patient',
+            valueReference: { reference: 'Patient/unknown_patient' }
+          }
+        ]
+      })
+      .expect(404)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(404);
+        expect(response.body.issue[0].details.text).toEqual(
+          'The following patient ids are not available on the server: Patient/unknown_patient'
+        );
+      });
+  });
+
   afterEach(async () => {
     await cleanUpDb();
   });

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -466,6 +466,28 @@ describe('Check group-level export logic (failure)', () => {
       });
   });
 
+  test('throws 404 when patient param includes a patient that does not belong to the group', async () => {
+    await supertest(app.server)
+      .post(`/Group/${GROUP_ID}/$export`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'patient',
+            valueReference: { reference: 'Patient/unknown_patient' }
+          }
+        ]
+      })
+      .expect(404)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(404);
+        expect(response.body.issue[0].details.text).toEqual(
+          `The following patient ids are not members of the group ${GROUP_ID}: Patient/unknown_patient`
+        );
+      });
+  });
+
   afterEach(async () => {
     await cleanUpDb();
   });

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -293,6 +293,41 @@ describe('Check barebones bulk export logic (failure)', () => {
       });
   });
 
+  test('throws 400 error when POST request body is not of resourceType "Parameters"', async () => {
+    await supertest(app.server)
+      .post('/$export')
+      .send({
+        resourceType: 'Patient',
+        parameter: [
+          {
+            name: 'patient',
+            valueString: 'test'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body of resourceType "Parameters."'
+        );
+      });
+  });
+
+  test('throws 400 error when method is POST and parameters are supplied in the url', async () => {
+    await supertest(app.server)
+      .post(`/Patient/$export?_type=Encounter`)
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body for POST requests.'
+        );
+      });
+  });
+
   afterEach(async () => {
     await cleanUpDb();
   });
@@ -416,6 +451,41 @@ describe('Check patient-level export logic (failure)', () => {
         expect(response.body.issue[0].code).toEqual(404);
         expect(response.body.issue[0].details.text).toEqual(
           'The following patient ids are not available on the server: Patient/unknown_patient'
+        );
+      });
+  });
+
+  test('throws 400 error when POST request body is not of resourceType "Parameters"', async () => {
+    await supertest(app.server)
+      .post('/Patient/$export')
+      .send({
+        resourceType: 'Patient',
+        parameter: [
+          {
+            name: 'patient',
+            valueString: 'test'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body of resourceType "Parameters."'
+        );
+      });
+  });
+
+  test('throws 400 error when method is POST and parameters are supplied in the url', async () => {
+    await supertest(app.server)
+      .post(`/Patient/$export?_type=Encounter`)
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body for POST requests.'
         );
       });
   });
@@ -548,6 +618,41 @@ describe('Check group-level export logic (failure)', () => {
         expect(response.body.issue[0].code).toEqual(400);
         expect(response.body.issue[0].details.text).toEqual(
           'All patient references must be of the format "Patient/{id}" for the "patient" parameter.'
+        );
+      });
+  });
+
+  test('throws 400 error when POST request body is not of resourceType "Parameters"', async () => {
+    await supertest(app.server)
+      .post(`/Group/${GROUP_ID}/$export`)
+      .send({
+        resourceType: 'Patient',
+        parameter: [
+          {
+            name: 'patient',
+            valueString: 'test'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body of resourceType "Parameters."'
+        );
+      });
+  });
+
+  test('throws 400 error when method is POST and parameters are supplied in the url', async () => {
+    await supertest(app.server)
+      .post(`/Group/${GROUP_ID}/$export?_type=Encounter`)
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'Parameters must be specified in a request body for POST requests.'
         );
       });
   });

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -27,10 +27,41 @@ describe('Check barebones bulk export logic (success)', () => {
       });
   });
 
+  test('check 202 returned and content-location populated for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/$export')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
   test('check 202 returned and content-location populated with params', async () => {
     const createJobSpy = jest.spyOn(queue, 'createJob');
     await supertest(app.server)
       .get('/$export?_outputFormat=ndjson')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('check 202 returned and content-location populated with params for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: '_type',
+            valueString: 'Patient'
+          }
+        ]
+      })
       .expect(202)
       .then(response => {
         expect(response.headers['content-location']).toBeDefined();
@@ -60,10 +91,41 @@ describe('Check patient-level export logic (success)', () => {
       });
   });
 
+  test('check 202 returned and content-location populated for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/Patient/$export')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
   test('check 202 returned and content-location populated with params', async () => {
     const createJobSpy = jest.spyOn(queue, 'createJob');
     await supertest(app.server)
       .get('/Patient/$export?_outputFormat=ndjson&_type=Patient,ServiceRequest')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('check 202 returned and content-location populated with params for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: '_type',
+            valueString: 'Patient'
+          }
+        ]
+      })
       .expect(202)
       .then(response => {
         expect(response.headers['content-location']).toBeDefined();
@@ -101,6 +163,37 @@ describe('Check group-level export logic (success)', () => {
     const createJobSpy = jest.spyOn(queue, 'createJob');
     await supertest(app.server)
       .get('/Group/testGroup/$export')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('check 202 returned and content-location populated for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/Group/testGroup/$export')
+      .expect(202)
+      .then(response => {
+        expect(response.headers['content-location']).toBeDefined();
+        expect(createJobSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('check 202 returned and content-location populated with params for POST request', async () => {
+    const createJobSpy = jest.spyOn(queue, 'createJob');
+    await supertest(app.server)
+      .post('/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: '_type',
+            valueString: 'Patient'
+          }
+        ]
+      })
       .expect(202)
       .then(response => {
         expect(response.headers['content-location']).toBeDefined();
@@ -174,6 +267,28 @@ describe('Check barebones bulk export logic (failure)', () => {
         expect(response.body.issue[0].code).toEqual(400);
         expect(response.body.issue[0].details.text).toEqual(
           'The following resourceTypes are not supported for _typeFilter param for $export: invalid.'
+        );
+      });
+  });
+
+  test('throws 400 error when "patient" parameter used in system-level export', async () => {
+    await supertest(app.server)
+      .post('/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'patient',
+            valueString: 'test'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'The "patient" parameter cannot be used in a system-level export request.'
         );
       });
   });

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -377,6 +377,27 @@ describe('Check patient-level export logic (failure)', () => {
       });
   });
 
+  test('throws 400 error when patient param is supplied with invalid format', async () => {
+    await supertest(app.server)
+      .post('/Patient/$export')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'patient',
+            valueReference: { reference: 'testPatient' }
+          }
+        ]
+      })
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'All patient references must be of the format "Patient/{id}" for the "patient" parameter.'
+        );
+      });
+  });
+
   test('throws 404 when patient param is supplied with a patient that is not on the server', async () => {
     await supertest(app.server)
       .post('/Patient/$export')
@@ -506,6 +527,27 @@ describe('Check group-level export logic (failure)', () => {
         expect(response.body.issue[0].code).toEqual(404);
         expect(response.body.issue[0].details.text).toEqual(
           `The following patient ids are not members of the group ${GROUP_ID}: Patient/unknown_patient`
+        );
+      });
+  });
+
+  test('throws 400 error when patient param is supplied with invalid format', async () => {
+    await supertest(app.server)
+      .post(`/Group/${GROUP_ID}/$export`)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'patient',
+            valueReference: { reference: 'testPatient' }
+          }
+        ]
+      })
+      .then(response => {
+        expect(response.body.resourceType).toEqual('OperationOutcome');
+        expect(response.body.issue[0].code).toEqual(400);
+        expect(response.body.issue[0].details.text).toEqual(
+          'All patient references must be of the format "Patient/{id}" for the "patient" parameter.'
         );
       });
   });

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -90,88 +90,95 @@ describe('check export logic', () => {
   });
 
   describe('getDocuments', () => {
-    test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z', async () => {
-      const property = {
-        recordedDate: 'gt2019-01-03T00:00:00Z'
-      };
-      const searchParams = buildSearchParamList('Condition');
-      const filter = qb.buildSearchQuery({
-        req: { method: 'GET', query: property, params: {} },
-        parameterDefinitions: searchParams,
-        includeArchived: true
+    describe('_typeFilter tests', () => {
+      test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z', async () => {
+        const property = {
+          recordedDate: 'gt2019-01-03T00:00:00Z'
+        };
+        const searchParams = buildSearchParamList('Condition');
+        const filter = qb.buildSearchQuery({
+          req: { method: 'GET', query: property, params: {} },
+          parameterDefinitions: searchParams,
+          includeArchived: true
+        });
+        const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
+        expect(docObj.document.length).toEqual(1);
       });
-      const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
-      expect(docObj.document.length).toEqual(1);
-    });
 
-    test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=gt2019-01-03T00:00:00Z', async () => {
-      // test for the "&" operator within the query
-      const properties = {
-        recordedDate: 'gt2019-01-03T00:00:00Z',
-        onsetDateTime: 'gt2019-01-03T00:00:00Z'
-      };
-      const searchParams = buildSearchParamList('Condition');
-      const filter = qb.buildSearchQuery({
-        req: { method: 'GET', query: properties, params: {} },
-        parameterDefinitions: searchParams,
-        includeArchived: true
+      test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=gt2019-01-03T00:00:00Z', async () => {
+        // test for the "&" operator within the query
+        const properties = {
+          recordedDate: 'gt2019-01-03T00:00:00Z',
+          onsetDateTime: 'gt2019-01-03T00:00:00Z'
+        };
+        const searchParams = buildSearchParamList('Condition');
+        const filter = qb.buildSearchQuery({
+          req: { method: 'GET', query: properties, params: {} },
+          parameterDefinitions: searchParams,
+          includeArchived: true
+        });
+        const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
+        expect(docObj.document.length).toEqual(1);
       });
-      const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
-      expect(docObj.document.length).toEqual(1);
-    });
 
-    test('returns no documents when _typeFilter filters out all documents (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
-      const properties = {
-        recordedDate: 'gt2019-01-03T00:00:00Z',
-        onsetDateTime: 'lt2019-01-03T00:00:00Z'
-      };
-      const searchParams = buildSearchParamList('Condition');
-      const filter = qb.buildSearchQuery({
-        req: { method: 'GET', query: properties, params: {} },
-        parameterDefinitions: searchParams,
-        includeArchived: true
+      test('returns no documents when _typeFilter filters out all documents (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
+        const properties = {
+          recordedDate: 'gt2019-01-03T00:00:00Z',
+          onsetDateTime: 'lt2019-01-03T00:00:00Z'
+        };
+        const searchParams = buildSearchParamList('Condition');
+        const filter = qb.buildSearchQuery({
+          req: { method: 'GET', query: properties, params: {} },
+          parameterDefinitions: searchParams,
+          includeArchived: true
+        });
+        const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
+        expect(docObj.document.length).toEqual(0);
       });
-      const docObj = await getDocuments('Condition', [filter.query], undefined, ['testPatient']);
-      expect(docObj.document.length).toEqual(0);
-    });
 
-    test('returns Condition document when _typeFilter has "or" condition (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z,onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
-      const recordedDateProperty = {
-        recordedDate: 'gt2019-01-03T00:00:00Z'
-      };
-      const onsetDateTimeProperty = {
-        onsetDateTime: 'lt2019-01-03T00:00:00Z'
-      };
-      const searchParams = buildSearchParamList('Condition');
-      const recordedDateFilter = qb.buildSearchQuery({
-        req: { method: 'GET', query: recordedDateProperty, params: {} },
-        parameterDefinitions: searchParams,
-        includeArchived: true
+      test('returns Condition document when _typeFilter has "or" condition (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z,onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
+        const recordedDateProperty = {
+          recordedDate: 'gt2019-01-03T00:00:00Z'
+        };
+        const onsetDateTimeProperty = {
+          onsetDateTime: 'lt2019-01-03T00:00:00Z'
+        };
+        const searchParams = buildSearchParamList('Condition');
+        const recordedDateFilter = qb.buildSearchQuery({
+          req: { method: 'GET', query: recordedDateProperty, params: {} },
+          parameterDefinitions: searchParams,
+          includeArchived: true
+        });
+        const onsetDateTimeFilter = qb.buildSearchQuery({
+          req: { method: 'GET', query: onsetDateTimeProperty, params: {} },
+          parameterDefinitions: searchParams,
+          includeArchived: true
+        });
+        const docObj = await getDocuments(
+          'Condition',
+          [recordedDateFilter.query, onsetDateTimeFilter.query],
+          undefined,
+          ['testPatient']
+        );
+        expect(docObj.document.length).toEqual(1);
       });
-      const onsetDateTimeFilter = qb.buildSearchQuery({
-        req: { method: 'GET', query: onsetDateTimeProperty, params: {} },
-        parameterDefinitions: searchParams,
-        includeArchived: true
+    });
+
+    describe('Patient-based filtering tests', () => {
+      test('Expect getDocuments to find a resource associated with a patient (Group export)', async () => {
+        const docObj = await getDocuments('Encounter', undefined, undefined, ['testPatient']);
+        expect(docObj.document.length).toEqual(1);
       });
-      const docObj = await getDocuments('Condition', [recordedDateFilter.query, onsetDateTimeFilter.query], undefined, [
-        'testPatient'
-      ]);
-      expect(docObj.document.length).toEqual(1);
-    });
 
-    test('Expect getDocuments to find a resource associated with a patient (Group export)', async () => {
-      const docObj = await getDocuments('Encounter', undefined, undefined, ['testPatient']);
-      expect(docObj.document.length).toEqual(1);
-    });
+      test('Expect getDocuments to find the encounter resource with no patient association (Patient export)', async () => {
+        const docObj = await getDocuments('Encounter', undefined, undefined, undefined);
+        expect(docObj.document.length).toEqual(1);
+      });
 
-    test('Expect getDocuments to find the encounter resource with no patient association (Patient export)', async () => {
-      const docObj = await getDocuments('Encounter', undefined, undefined, undefined);
-      expect(docObj.document.length).toEqual(1);
-    });
-
-    test('Expect getDocuments to return empty results for 0 patient association (empty Group)', async () => {
-      const docObj = await getDocuments('Encounter', undefined, undefined, []);
-      expect(docObj.document.length).toEqual(0);
+      test('Expect getDocuments to return empty results for 0 patient association (empty Group)', async () => {
+        const docObj = await getDocuments('Encounter', undefined, undefined, []);
+        expect(docObj.document.length).toEqual(0);
+      });
     });
   });
 

--- a/test/util/groupUtils.test.js
+++ b/test/util/groupUtils.test.js
@@ -1,0 +1,9 @@
+const testPatient = require('../fixtures/testPatient.json');
+const { createPatientGroupsPerMeasure } = require('../../src/util/groupUtils');
+
+describe('createPatientGroupsPerMeasure', () => {
+  test('Successfully creates group containing input patient', async () => {
+    const result = await createPatientGroupsPerMeasure('test-id', [testPatient.id]);
+    expect(result).toEqual(true);
+  });
+});

--- a/test/util/groupUtils.test.js
+++ b/test/util/groupUtils.test.js
@@ -13,10 +13,10 @@ describe('createPatientGroupsPerMeasure', () => {
   afterEach(async () => {
     await cleanUpDb();
   });
+});
 
-  // Close export queue that is created when processing these tests
-  // TODO: investigate why queues are leaving open handles in this file
-  afterAll(async () => {
-    await queue.close();
-  });
+// Close export queue that is created when processing these tests
+// TODO: investigate why queues are leaving open handles in this file
+afterAll(async () => {
+  await queue.close();
 });

--- a/test/util/groupUtils.test.js
+++ b/test/util/groupUtils.test.js
@@ -1,9 +1,22 @@
 const testPatient = require('../fixtures/testPatient.json');
+const { cleanUpDb } = require('../populateTestData');
 const { createPatientGroupsPerMeasure } = require('../../src/util/groupUtils');
-
+// import queue to close open handles after tests pass
+// TODO: investigate why queues are leaving open handles in this file
+const queue = require('../../src/resources/exportQueue');
 describe('createPatientGroupsPerMeasure', () => {
   test('Successfully creates group containing input patient', async () => {
     const result = await createPatientGroupsPerMeasure('test-id', [testPatient.id]);
     expect(result).toEqual(true);
+  });
+
+  afterEach(async () => {
+    await cleanUpDb();
+  });
+
+  // Close export queue that is created when processing these tests
+  // TODO: investigate why queues are leaving open handles in this file
+  afterAll(async () => {
+    await queue.close();
   });
 });

--- a/test/util/valueSetHelper.test.js
+++ b/test/util/valueSetHelper.test.js
@@ -1,0 +1,76 @@
+const { getHierarchicalCodes, getCodesFromValueSet } = require('../../src/util/valueSetHelper');
+
+describe('getHierarchicalCodes', () => {
+  test('Returns array of codes in ValueSet', () => {
+    const valueSetArray = [
+      {
+        code: 'testCode',
+        system: 'testSystem',
+        version: 'testVersion',
+        display: 'testDisplay',
+        expansion: {}
+      }
+    ];
+
+    const expected_codes = [
+      {
+        code: 'testCode',
+        system: 'testSystem',
+        version: 'testVersion',
+        display: 'testDisplay'
+      }
+    ];
+    const results = getHierarchicalCodes(valueSetArray);
+    expect(results).toEqual(expected_codes);
+  });
+});
+
+describe('getCodesFromValueSet', () => {
+  const expected_codes = [
+    {
+      code: 'testCode',
+      system: 'testSystem',
+      version: 'testVersion',
+      display: 'testDisplay'
+    }
+  ];
+  test('gets hierarchical codes when expansion is defined', () => {
+    const valueSet = {
+      resourceType: 'ValueSet',
+      expansion: {
+        contains: [
+          {
+            code: 'testCode',
+            system: 'testSystem',
+            version: 'testVersion',
+            display: 'testDisplay'
+          }
+        ]
+      }
+    };
+    const results = getCodesFromValueSet(valueSet);
+    expect(results).toEqual(expected_codes);
+  });
+
+  test('gets codes from compose if expansion does not exist', () => {
+    const valueSet = {
+      resourceType: 'ValueSet',
+      compose: {
+        include: [
+          {
+            system: 'testSystem',
+            version: 'testVersion',
+            concept: [
+              {
+                code: 'testCode',
+                display: 'testDisplay'
+              }
+            ]
+          }
+        ]
+      }
+    };
+    const results = getCodesFromValueSet(valueSet);
+    expect(results).toEqual(expected_codes);
+  });
+});

--- a/test/util/valueSetHelper.test.js
+++ b/test/util/valueSetHelper.test.js
@@ -75,10 +75,10 @@ describe('getCodesFromValueSet', () => {
     const results = getCodesFromValueSet(valueSet);
     expect(results).toEqual(expected_codes);
   });
+});
 
-  // Close export queue that is created when processing these tests
-  // TODO: investigate why queues are leaving open handles in this file
-  afterEach(async () => {
-    await queue.close();
-  });
+// Close export queue that is created when processing these tests
+// TODO: investigate why queues are leaving open handles in this file
+afterAll(async () => {
+  await queue.close();
 });

--- a/test/util/valueSetHelper.test.js
+++ b/test/util/valueSetHelper.test.js
@@ -1,5 +1,7 @@
 const { getHierarchicalCodes, getCodesFromValueSet } = require('../../src/util/valueSetHelper');
-
+// import queue to close open handles after tests pass
+// TODO: investigate why queues are leaving open handles in this file
+const queue = require('../../src/resources/exportQueue');
 describe('getHierarchicalCodes', () => {
   test('Returns array of codes in ValueSet', () => {
     const valueSetArray = [
@@ -72,5 +74,11 @@ describe('getCodesFromValueSet', () => {
     };
     const results = getCodesFromValueSet(valueSet);
     expect(results).toEqual(expected_codes);
+  });
+
+  // Close export queue that is created when processing these tests
+  // TODO: investigate why queues are leaving open handles in this file
+  afterEach(async () => {
+    await queue.close();
   });
 });


### PR DESCRIPTION
# Summary
Adds support for the [patient parameter](https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters) for bulk data export.

## New behavior

The user can now send POST requests for all three types of export. The [bulk data kick-off request docs](https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-kick-off-request) note that “A server SHALL support GET requests and MAY support POST requests that supply parameters using the FHIR Parameters Resource.” The new `patient` parameter needs to be included via POST.

The user can now send a request with the `patient` parameter. The `patient` parameter is only applicable to patient-level and group-level export requests. When provided, the server SHALL NOT return resources in the patient compartment definition belonging to patients outside the list. The `patient` parameter is of type FHIR Reference, and multiple patients should be supported by the server. The `patient` parameter essentially acts as a patient-based filter in a similar way that group-level export applies patient-based filtering.

When the `patient` parameter is provided, the exported NDJSON is filtered based on the provided patient references. Resources that are in the patient compartment definition that do not reference the patients are not returned from the bulk export.

## Code changes
* Add support for POST requests - changes appear in `src/server/app.js`, `src/services/export.service.js` and in `test/services/export.service.test.js`
* `patient` is added the export queue jobs (`src/server/exportWorker.js`, `src/services/export.service.js`)
* Add functionality for retrieving parameters from a POST body (`gatherParams`) and validate the format of the `patient` param (`src/services/export.service.js`)
* Pass the `patient` param, if present, into the filtering logic (`src/util/exportToNDJson.js`)
        * Fortunately, the filtering logic in `exportToNDJson` already accounts for filtering via patient id, as it does so when ids are provided from a group. This logic is reused with the `patient` references, building an `$or` query for the references that are provided in the request.
* Various cases of error handling for edge cases (`patient` provided in a GET, patient does not exist on server, patient does not exist in group, etc.)
* Made updates to `ci.yml`: updates node version and mongo version, updates jest command for coverage report (based off the coverage report used for fqm-execution ci)

# Testing guidance
* Run unit tests
* An Insomnia import is attached to the pull request that contains requests that can be used for testing. These tests assume that the repository’s `upload-bundles` script has been run and that the server is loaded with groups created from that script. The tests are performed on the Cervical Cancer Screening measure, but the request urls and bodies can be tailored to other measures and parameter values.

A big concern with bulk data is the interaction between different parameters, and that should be kept in mind throughout testing. Make sure to test different combinations of `_type`, `_typeFilter`, and `patient`.
[bulk_patient_param_insomnia.json](https://github.com/projecttacoma/bulk-export-server/files/13590832/bulk_patient_param_insomnia.json)
