### PR TITLE
Add support for the _elements param

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The server supports the following query parameters:
 
 #### `_elements` Query Parameter
 
-The server supports the optional and experimental query parameter `_elements` as defined by the Bulk Data Access IG (here)[https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters]. The `_elements` parameter is a string of comma-delimited HL7® FHIR® Elements filter the returned resources to only include listed elements and mandatory elements. Mandatory elements are defined as elements in the StructureDefinition of a resource type have a minimum cardinality of 1. Because this server provides json-formatted data, `resourceType` is also an implied mandatory element for all Resources.
+The server supports the optional and experimental query parameter `_elements` as defined by the Bulk Data Access IG (here)[https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters]. The `_elements` parameter is a string of comma-delimited HL7® FHIR® Elements used to filter the returned resources to only include listed elements and mandatory elements. Mandatory elements are defined as elements in the StructureDefinition of a resource type which have a minimum cardinality of 1. Because this server provides json-formatted data, `resourceType` is also an implied mandatory element for all Resources.
 
 The returned resources are only filtered by elements that are applicable to them. For example, if a request looks like the following:
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ The server supports the following query parameters:
 - `_outputFormat`: The server supports the following formats: `application/fhir+ndjson`, `application/ndjson+fhir`, `application/ndjson`, `ndjson`
 - `_typeFilter`: Filters the response to only include resources that meet the criteria of the specified comma-delimited FHIR REST queries. Returns an error for queries specified by the client that are unsupported by the server. Supports queries on the ValueSets (`type:in`, `code:in`, etc.) of a given resource type.
 - `patient`: Only applicable to POST requests for group-level and patient-level requests. When provided, the server SHALL NOT return resources in the patient compartment definition belonging to patients outside the list. Can support multiple patient references in a single request.
-- `_elements`: Filters the content of the responses to omit unlisted, non-mandatory elements form the resources returned. These elements should be provided in the form `[resource type].[element name]` (e.g., `Patient.id`) which only filters the contents of those specified resources or in the form `[element name]` (e.g., `id`) which filters the contents of all of the returned resources.
+- `_elements`: Filters the content of the responses to omit unlisted, non-mandatory elements from the resources returned. These elements should be provided in the form `[resource type].[element name]` (e.g., `Patient.id`) which only filters the contents of those specified resources or in the form `[element name]` (e.g., `id`) which filters the contents of all of the returned resources.
 
 #### `_elements` Query Parameter
 
-The server supports the optional and experimental query parameter `_elements` as defined by the Bulk Data Access IG (here)[https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters]. The `_elements` parameter is a string of comma-delimited HL7® FHIR® Elements filter the returned resources to only include listed elements and mandatory elements. Mandatory elements are defined as elements in the StructureDefinition of a resource type have a minimum cardinality of 1.
+The server supports the optional and experimental query parameter `_elements` as defined by the Bulk Data Access IG (here)[https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters]. The `_elements` parameter is a string of comma-delimited HL7® FHIR® Elements filter the returned resources to only include listed elements and mandatory elements. Mandatory elements are defined as elements in the StructureDefinition of a resource type have a minimum cardinality of 1. Because this server provides json-formatted data, `resourceType` is also an implied mandatory element for all Resources.
 
 The returned resources are only filtered by elements that are applicable to them. For example, if a request looks like the following:
 
@@ -174,7 +174,7 @@ If a request does not specify a resource type, such as the following:
 GET http://localhost:3000/$export?_elements=id
 ```
 
-Then the returned resources should only contain an `id` (if applicable) and any mandatory elements.
+Then all returned resources should only contain an `id` (if applicable) and any mandatory elements.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,27 @@ The server supports the following query parameters:
 - `_outputFormat`: The server supports the following formats: `application/fhir+ndjson`, `application/ndjson+fhir`, `application/ndjson`, `ndjson`
 - `_typeFilter`: Filters the response to only include resources that meet the criteria of the specified comma-delimited FHIR REST queries. Returns an error for queries specified by the client that are unsupported by the server. Supports queries on the ValueSets (`type:in`, `code:in`, etc.) of a given resource type.
 - `patient`: Only applicable to POST requests for group-level and patient-level requests. When provided, the server SHALL NOT return resources in the patient compartment definition belonging to patients outside the list. Can support multiple patient references in a single request.
+- `_elements`: Filters the content of the responses to omit unlisted, non-mandatory elements form the resources returned. These elements should be provided in the form `[resource type].[element name]` (e.g., `Patient.id`) which only filters the contents of those specified resources or in the form `[element name]` (e.g., `id`) which filters the contents of all of the returned resources.
+
+#### `_elements` Query Parameter
+
+The server supports the optional and experimental query parameter `_elements` as defined by the Bulk Data Access IG (here)[https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters]. The `_elements` parameter is a string of comma-delimited HL7® FHIR® Elements filter the returned resources to only include listed elements and mandatory elements. Mandatory elements are defined as elements in the StructureDefinition of a resource type have a minimum cardinality of 1.
+
+The returned resources are only filtered by elements that are applicable to them. For example, if a request looks like the following:
+
+```
+GET http://localhost:3000/$export?_elements=Condition.id
+```
+
+Then the returned resources should contain everything on them except the returned Conditions should only contain an `id` (if applicable) and any mandatory elements.
+
+If a request does not specify a resource type, such as the following:
+
+```
+GET http://localhost:3000/$export?_elements=id
+```
+
+Then the returned resources should only contain an `id` (if applicable) and any mandatory elements.
 
 ## License
 

--- a/src/compartment-definition/choice-types.json
+++ b/src/compartment-definition/choice-types.json
@@ -1,0 +1,473 @@
+{
+  "Account": {},
+  "ActivityDefinition": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "timing[x]": [
+      "Timing",
+      "dateTime",
+      "Age",
+      "Period",
+      "Range",
+      "Duration"
+    ],
+    "product[x]": [
+      "Reference",
+      "CodeableConcept"
+    ]
+  },
+  "AdverseEvent": {},
+  "AllergyIntolerance": {
+    "onset[x]": [
+      "dateTime",
+      "Age",
+      "Period",
+      "Range",
+      "string"
+    ]
+  },
+  "Appointment": {},
+  "AppointmentResponse": {},
+  "AuditEvent": {},
+  "Basic": {},
+  "Binary": {},
+  "BiologicallyDerivedProduct": {},
+  "BodyStructure": {},
+  "Bundle": {},
+  "CapabilityStatement": {},
+  "CarePlan": {},
+  "CareTeam": {},
+  "CatalogEntry": {},
+  "ChargeItem": {
+    "occurrence[x]": [
+      "dateTime",
+      "Period",
+      "Timing"
+    ],
+    "product[x]": [
+      "Reference",
+      "CodeableConcept"
+    ]
+  },
+  "ChargeItemDefinition": {},
+  "Claim": {},
+  "ClaimResponse": {},
+  "ClinicalImpression": {
+    "effective[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "CodeSystem": {},
+  "Communication": {},
+  "CommunicationRequest": {
+    "occurrence[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "CompartmentDefinition": {},
+  "Composition": {},
+  "ConceptMap": {
+    "source[x]": [
+      "uri",
+      "canonical"
+    ],
+    "target[x]": [
+      "uri",
+      "canonical"
+    ]
+  },
+  "Condition": {
+    "onset[x]": [
+      "dateTime",
+      "Age",
+      "Period",
+      "Range",
+      "string"
+    ],
+    "abatement[x]": [
+      "dateTime",
+      "Age",
+      "Period",
+      "Range",
+      "string"
+    ]
+  },
+  "Consent": {
+    "source[x]": [
+      "Attachment",
+      "Reference"
+    ]
+  },
+  "Contract": {
+    "topic[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "legallyBinding[x]": [
+      "Attachment",
+      "Reference"
+    ]
+  },
+  "Coverage": {},
+  "CoverageEligibilityRequest": {
+    "serviced[x]": [
+      "date",
+      "Period"
+    ]
+  },
+  "CoverageEligibilityResponse": {
+    "serviced[x]": [
+      "date",
+      "Period"
+    ]
+  },
+  "DetectedIssue": {
+    "identified[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "Device": {},
+  "DeviceDefinition": {
+    "manufacturer[x]": [
+      "string",
+      "Reference"
+    ]
+  },
+  "DeviceMetric": {},
+  "DeviceRequest": {
+    "code[x]": [
+      "Reference",
+      "CodeableConcept"
+    ],
+    "occurrence[x]": [
+      "dateTime",
+      "Period",
+      "Timing"
+    ]
+  },
+  "DeviceUseStatement": {
+    "timing[x]": [
+      "Timing",
+      "Period",
+      "dateTime"
+    ]
+  },
+  "DiagnosticReport": {
+    "effective[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "DocumentManifest": {},
+  "DocumentReference": {},
+  "EffectEvidenceSynthesis": {},
+  "Encounter": {},
+  "Endpoint": {},
+  "EnrollmentRequest": {},
+  "EnrollmentResponse": {},
+  "EpisodeOfCare": {},
+  "EventDefinition": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "Evidence": {},
+  "EvidenceVariable": {},
+  "ExampleScenario": {},
+  "ExplanationOfBenefit": {},
+  "FamilyMemberHistory": {
+    "born[x]": [
+      "Period",
+      "date",
+      "string"
+    ],
+    "age[x]": [
+      "Age",
+      "Range",
+      "string"
+    ],
+    "deceased[x]": [
+      "boolean",
+      "Age",
+      "Range",
+      "date",
+      "string"
+    ]
+  },
+  "Flag": {},
+  "Goal": {
+    "start[x]": [
+      "date",
+      "CodeableConcept"
+    ]
+  },
+  "GraphDefinition": {},
+  "Group": {},
+  "GuidanceResponse": {
+    "module[x]": [
+      "uri",
+      "canonical",
+      "CodeableConcept"
+    ]
+  },
+  "HealthcareService": {},
+  "ImagingStudy": {},
+  "Immunization": {
+    "occurrence[x]": [
+      "dateTime",
+      "string"
+    ]
+  },
+  "ImmunizationEvaluation": {
+    "doseNumber[x]": [
+      "positiveInt",
+      "string"
+    ],
+    "seriesDoses[x]": [
+      "positiveInt",
+      "string"
+    ]
+  },
+  "ImmunizationRecommendation": {},
+  "ImplementationGuide": {},
+  "InsurancePlan": {},
+  "Invoice": {},
+  "Library": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "Linkage": {},
+  "List": {},
+  "Location": {},
+  "Measure": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "MeasureReport": {},
+  "Media": {
+    "created[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "Medication": {},
+  "MedicationAdministration": {
+    "medication[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "effective[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "MedicationDispense": {
+    "statusReason[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "medication[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "MedicationKnowledge": {},
+  "MedicationRequest": {
+    "reported[x]": [
+      "boolean",
+      "Reference"
+    ],
+    "medication[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "MedicationStatement": {
+    "medication[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "effective[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "MedicinalProduct": {},
+  "MedicinalProductAuthorization": {},
+  "MedicinalProductContraindication": {},
+  "MedicinalProductIndication": {},
+  "MedicinalProductIngredient": {},
+  "MedicinalProductInteraction": {},
+  "MedicinalProductManufactured": {},
+  "MedicinalProductPackaged": {},
+  "MedicinalProductPharmaceutical": {},
+  "MedicinalProductUndesirableEffect": {},
+  "MessageDefinition": {
+    "event[x]": [
+      "Coding",
+      "uri"
+    ]
+  },
+  "MessageHeader": {
+    "event[x]": [
+      "Coding",
+      "uri"
+    ]
+  },
+  "MolecularSequence": {},
+  "NamingSystem": {},
+  "NutritionOrder": {},
+  "Observation": {
+    "effective[x]": [
+      "dateTime",
+      "Period",
+      "Timing",
+      "instant"
+    ],
+    "value[x]": [
+      "Quantity",
+      "CodeableConcept",
+      "string",
+      "boolean",
+      "integer",
+      "Range",
+      "Ratio",
+      "SampledData",
+      "time",
+      "dateTime",
+      "Period"
+    ]
+  },
+  "ObservationDefinition": {},
+  "OperationDefinition": {},
+  "OperationOutcome": {},
+  "Organization": {},
+  "OrganizationAffiliation": {},
+  "Parameters": {},
+  "Patient": {
+    "deceased[x]": [
+      "boolean",
+      "dateTime"
+    ],
+    "multipleBirth[x]": [
+      "boolean",
+      "integer"
+    ]
+  },
+  "PaymentNotice": {},
+  "PaymentReconciliation": {},
+  "Person": {},
+  "PlanDefinition": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "Practitioner": {},
+  "PractitionerRole": {},
+  "Procedure": {
+    "performed[x]": [
+      "dateTime",
+      "Period",
+      "string",
+      "Age",
+      "Range"
+    ]
+  },
+  "Provenance": {
+    "occurred[x]": [
+      "Period",
+      "dateTime"
+    ]
+  },
+  "Questionnaire": {},
+  "QuestionnaireResponse": {},
+  "RelatedPerson": {},
+  "RequestGroup": {},
+  "ResearchDefinition": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "ResearchElementDefinition": {
+    "subject[x]": [
+      "CodeableConcept",
+      "Reference"
+    ]
+  },
+  "ResearchStudy": {},
+  "ResearchSubject": {},
+  "RiskAssessment": {
+    "occurrence[x]": [
+      "dateTime",
+      "Period"
+    ]
+  },
+  "RiskEvidenceSynthesis": {},
+  "Schedule": {},
+  "SearchParameter": {},
+  "ServiceRequest": {
+    "quantity[x]": [
+      "Quantity",
+      "Ratio",
+      "Range"
+    ],
+    "occurrence[x]": [
+      "dateTime",
+      "Period",
+      "Timing"
+    ],
+    "asNeeded[x]": [
+      "boolean",
+      "CodeableConcept"
+    ]
+  },
+  "Slot": {},
+  "Specimen": {},
+  "SpecimenDefinition": {},
+  "StructureDefinition": {},
+  "StructureMap": {},
+  "Subscription": {},
+  "Substance": {},
+  "SubstancePolymer": {},
+  "SubstanceProtein": {},
+  "SubstanceReferenceInformation": {},
+  "SubstanceSourceMaterial": {},
+  "SubstanceSpecification": {},
+  "SupplyDelivery": {
+    "occurrence[x]": [
+      "dateTime",
+      "Period",
+      "Timing"
+    ]
+  },
+  "SupplyRequest": {
+    "item[x]": [
+      "CodeableConcept",
+      "Reference"
+    ],
+    "occurrence[x]": [
+      "dateTime",
+      "Period",
+      "Timing"
+    ]
+  },
+  "Task": {},
+  "TerminologyCapabilities": {},
+  "TestReport": {},
+  "TestScript": {},
+  "ValueSet": {},
+  "VerificationResult": {},
+  "VisionPrescription": {}
+}

--- a/src/compartment-definition/mandatory-elements.json
+++ b/src/compartment-definition/mandatory-elements.json
@@ -1,0 +1,566 @@
+{
+  "Account": [
+    "status"
+  ],
+  "ActivityDefinition": [
+    "status"
+  ],
+  "AdverseEvent": [
+    "actuality",
+    "subject"
+  ],
+  "AllergyIntolerance": [
+    "patient"
+  ],
+  "Appointment": [
+    "status",
+    "participant"
+  ],
+  "AppointmentResponse": [
+    "appointment",
+    "participantStatus"
+  ],
+  "AuditEvent": [
+    "type",
+    "recorded",
+    "agent",
+    "source"
+  ],
+  "Basic": [
+    "code"
+  ],
+  "Binary": [
+    "contentType"
+  ],
+  "BiologicallyDerivedProduct": [],
+  "BodyStructure": [
+    "patient"
+  ],
+  "Bundle": [
+    "type"
+  ],
+  "CapabilityStatement": [
+    "status",
+    "date",
+    "kind",
+    "fhirVersion",
+    "format"
+  ],
+  "CarePlan": [
+    "status",
+    "intent",
+    "subject"
+  ],
+  "CareTeam": [],
+  "CatalogEntry": [
+    "orderable",
+    "referencedItem"
+  ],
+  "ChargeItem": [
+    "status",
+    "code",
+    "subject"
+  ],
+  "ChargeItemDefinition": [
+    "url",
+    "status"
+  ],
+  "Claim": [
+    "status",
+    "type",
+    "use",
+    "patient",
+    "created",
+    "provider",
+    "priority",
+    "insurance"
+  ],
+  "ClaimResponse": [
+    "status",
+    "type",
+    "use",
+    "patient",
+    "created",
+    "insurer",
+    "outcome"
+  ],
+  "ClinicalImpression": [
+    "status",
+    "subject"
+  ],
+  "CodeSystem": [
+    "status",
+    "content"
+  ],
+  "Communication": [
+    "status"
+  ],
+  "CommunicationRequest": [
+    "status"
+  ],
+  "CompartmentDefinition": [
+    "url",
+    "name",
+    "status",
+    "code",
+    "search"
+  ],
+  "Composition": [
+    "status",
+    "type",
+    "date",
+    "author",
+    "title"
+  ],
+  "ConceptMap": [
+    "status"
+  ],
+  "Condition": [
+    "subject"
+  ],
+  "Consent": [
+    "status",
+    "scope",
+    "category"
+  ],
+  "Contract": [],
+  "Coverage": [
+    "status",
+    "beneficiary",
+    "payor"
+  ],
+  "CoverageEligibilityRequest": [
+    "status",
+    "purpose",
+    "patient",
+    "created",
+    "insurer"
+  ],
+  "CoverageEligibilityResponse": [
+    "status",
+    "purpose",
+    "patient",
+    "created",
+    "request",
+    "outcome",
+    "insurer"
+  ],
+  "DetectedIssue": [
+    "status"
+  ],
+  "Device": [],
+  "DeviceDefinition": [],
+  "DeviceMetric": [
+    "type",
+    "category"
+  ],
+  "DeviceRequest": [
+    "intent",
+    "code[x]",
+    "subject"
+  ],
+  "DeviceUseStatement": [
+    "status",
+    "subject",
+    "device"
+  ],
+  "DiagnosticReport": [
+    "status",
+    "code"
+  ],
+  "DocumentManifest": [
+    "status",
+    "content"
+  ],
+  "DocumentReference": [
+    "status",
+    "content"
+  ],
+  "EffectEvidenceSynthesis": [
+    "status",
+    "population",
+    "exposure",
+    "exposureAlternative",
+    "outcome"
+  ],
+  "Encounter": [
+    "status",
+    "class"
+  ],
+  "Endpoint": [
+    "status",
+    "connectionType",
+    "payloadType",
+    "address"
+  ],
+  "EnrollmentRequest": [],
+  "EnrollmentResponse": [],
+  "EpisodeOfCare": [
+    "status",
+    "patient"
+  ],
+  "EventDefinition": [
+    "status",
+    "trigger"
+  ],
+  "Evidence": [
+    "status",
+    "exposureBackground"
+  ],
+  "EvidenceVariable": [
+    "status",
+    "characteristic"
+  ],
+  "ExampleScenario": [
+    "status"
+  ],
+  "ExplanationOfBenefit": [
+    "status",
+    "type",
+    "use",
+    "patient",
+    "created",
+    "insurer",
+    "provider",
+    "outcome",
+    "insurance"
+  ],
+  "FamilyMemberHistory": [
+    "status",
+    "patient",
+    "relationship"
+  ],
+  "Flag": [
+    "status",
+    "code",
+    "subject"
+  ],
+  "Goal": [
+    "lifecycleStatus",
+    "description",
+    "subject"
+  ],
+  "GraphDefinition": [
+    "name",
+    "status",
+    "start"
+  ],
+  "Group": [
+    "type",
+    "actual"
+  ],
+  "GuidanceResponse": [
+    "module[x]",
+    "status"
+  ],
+  "HealthcareService": [],
+  "ImagingStudy": [
+    "status",
+    "subject"
+  ],
+  "Immunization": [
+    "status",
+    "vaccineCode",
+    "patient",
+    "occurrence[x]"
+  ],
+  "ImmunizationEvaluation": [
+    "status",
+    "patient",
+    "targetDisease",
+    "immunizationEvent",
+    "doseStatus"
+  ],
+  "ImmunizationRecommendation": [
+    "patient",
+    "date",
+    "recommendation"
+  ],
+  "ImplementationGuide": [
+    "url",
+    "name",
+    "status",
+    "packageId",
+    "fhirVersion"
+  ],
+  "InsurancePlan": [],
+  "Invoice": [
+    "status"
+  ],
+  "Library": [
+    "status",
+    "type"
+  ],
+  "Linkage": [
+    "item"
+  ],
+  "List": [
+    "status",
+    "mode"
+  ],
+  "Location": [],
+  "Measure": [
+    "status"
+  ],
+  "MeasureReport": [
+    "status",
+    "type",
+    "measure",
+    "period"
+  ],
+  "Media": [
+    "status",
+    "content"
+  ],
+  "Medication": [],
+  "MedicationAdministration": [
+    "status",
+    "medication[x]",
+    "subject",
+    "effective[x]"
+  ],
+  "MedicationDispense": [
+    "status",
+    "medication[x]"
+  ],
+  "MedicationKnowledge": [],
+  "MedicationRequest": [
+    "status",
+    "intent",
+    "medication[x]",
+    "subject"
+  ],
+  "MedicationStatement": [
+    "status",
+    "medication[x]",
+    "subject"
+  ],
+  "MedicinalProduct": [
+    "name"
+  ],
+  "MedicinalProductAuthorization": [],
+  "MedicinalProductContraindication": [],
+  "MedicinalProductIndication": [],
+  "MedicinalProductIngredient": [
+    "role"
+  ],
+  "MedicinalProductInteraction": [],
+  "MedicinalProductManufactured": [
+    "manufacturedDoseForm",
+    "quantity"
+  ],
+  "MedicinalProductPackaged": [
+    "packageItem"
+  ],
+  "MedicinalProductPharmaceutical": [
+    "administrableDoseForm",
+    "routeOfAdministration"
+  ],
+  "MedicinalProductUndesirableEffect": [],
+  "MessageDefinition": [
+    "status",
+    "date",
+    "event[x]"
+  ],
+  "MessageHeader": [
+    "event[x]",
+    "source"
+  ],
+  "MolecularSequence": [
+    "coordinateSystem"
+  ],
+  "NamingSystem": [
+    "name",
+    "status",
+    "kind",
+    "date",
+    "uniqueId"
+  ],
+  "NutritionOrder": [
+    "status",
+    "intent",
+    "patient",
+    "dateTime"
+  ],
+  "Observation": [
+    "status",
+    "code"
+  ],
+  "ObservationDefinition": [
+    "code"
+  ],
+  "OperationDefinition": [
+    "name",
+    "status",
+    "kind",
+    "code",
+    "system",
+    "type",
+    "instance"
+  ],
+  "OperationOutcome": [
+    "issue"
+  ],
+  "Organization": [],
+  "OrganizationAffiliation": [],
+  "Parameters": [],
+  "Patient": [],
+  "PaymentNotice": [
+    "status",
+    "created",
+    "payment",
+    "recipient",
+    "amount"
+  ],
+  "PaymentReconciliation": [
+    "status",
+    "created",
+    "paymentDate",
+    "paymentAmount"
+  ],
+  "Person": [],
+  "PlanDefinition": [
+    "status"
+  ],
+  "Practitioner": [],
+  "PractitionerRole": [],
+  "Procedure": [
+    "status",
+    "subject"
+  ],
+  "Provenance": [
+    "target",
+    "recorded",
+    "agent"
+  ],
+  "Questionnaire": [
+    "status"
+  ],
+  "QuestionnaireResponse": [
+    "status"
+  ],
+  "RelatedPerson": [
+    "patient"
+  ],
+  "RequestGroup": [
+    "status",
+    "intent"
+  ],
+  "ResearchDefinition": [
+    "status",
+    "population"
+  ],
+  "ResearchElementDefinition": [
+    "status",
+    "type",
+    "characteristic"
+  ],
+  "ResearchStudy": [
+    "status"
+  ],
+  "ResearchSubject": [
+    "status",
+    "study",
+    "individual"
+  ],
+  "RiskAssessment": [
+    "status",
+    "subject"
+  ],
+  "RiskEvidenceSynthesis": [
+    "status",
+    "population",
+    "outcome"
+  ],
+  "Schedule": [
+    "actor"
+  ],
+  "SearchParameter": [
+    "url",
+    "name",
+    "status",
+    "description",
+    "code",
+    "base",
+    "type"
+  ],
+  "ServiceRequest": [
+    "status",
+    "intent",
+    "subject"
+  ],
+  "Slot": [
+    "schedule",
+    "status",
+    "start",
+    "end"
+  ],
+  "Specimen": [],
+  "SpecimenDefinition": [],
+  "StructureDefinition": [
+    "url",
+    "name",
+    "status",
+    "kind",
+    "abstract",
+    "type"
+  ],
+  "StructureMap": [
+    "url",
+    "name",
+    "status",
+    "group"
+  ],
+  "Subscription": [
+    "status",
+    "reason",
+    "criteria",
+    "channel"
+  ],
+  "Substance": [
+    "code"
+  ],
+  "SubstancePolymer": [],
+  "SubstanceProtein": [],
+  "SubstanceReferenceInformation": [],
+  "SubstanceSourceMaterial": [],
+  "SubstanceSpecification": [],
+  "SupplyDelivery": [],
+  "SupplyRequest": [
+    "item[x]",
+    "quantity"
+  ],
+  "Task": [
+    "status",
+    "intent"
+  ],
+  "TerminologyCapabilities": [
+    "status",
+    "date",
+    "kind"
+  ],
+  "TestReport": [
+    "status",
+    "testScript",
+    "result"
+  ],
+  "TestScript": [
+    "url",
+    "name",
+    "status"
+  ],
+  "ValueSet": [
+    "status"
+  ],
+  "VerificationResult": [
+    "status"
+  ],
+  "VisionPrescription": [
+    "status",
+    "created",
+    "patient",
+    "dateWritten",
+    "prescriber",
+    "lensSpecification"
+  ]
+}

--- a/src/scripts/getChoiceTypesForResource.js
+++ b/src/scripts/getChoiceTypesForResource.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const STRUCTURE_DEFINITIONS_BASE_PATH = path.join(__dirname, '../resource-definitions');
+const choiceTypesOutputPath = path.resolve(path.join(__dirname, '../compartment-definition/choice-types.json'));
+
+/**
+ * Parse the StructureDefinition of resource types supported by this server for choice type elements
+ * The StructureDefinitions of each resource type is found in the FHIR R4 spec
+ *  * For example, the StructureDefinition for Encounter was found here: https://hl7.org/fhir/R4/encounter.profile.json.html
+ * @returns {Object} object whose keys are resourceTypes and values are objects whose keys are choice types
+ * whose values are an array of all the types it can be
+ */
+async function main() {
+  const files = fs.readdirSync(STRUCTURE_DEFINITIONS_BASE_PATH).map(f => ({
+    shortName: f.split('.profile')[0],
+    fullPath: path.join(STRUCTURE_DEFINITIONS_BASE_PATH, f)
+  }));
+
+  const choiceTypeElementsResults = {};
+
+  files.forEach(f => {
+    let choiceTypeElements = {};
+
+    // read the contents of the file
+    const structureDef = JSON.parse(fs.readFileSync(f.fullPath, 'utf8'));
+    structureDef.snapshot.element.forEach(e => {
+      if (e.path.endsWith('[x]') && e.path.split('.').length <= 2) {
+        const choiceType = e.id.split('.')[1];
+        let choiceTypeTypes = [];
+        e.type.forEach(type => {
+          choiceTypeTypes.push(type.code);
+        });
+        choiceTypeElements[choiceType] = choiceTypeTypes;
+      }
+    });
+    choiceTypeElementsResults[structureDef.id] = choiceTypeElements;
+  });
+
+  return choiceTypeElementsResults;
+}
+
+main()
+  .then(choiceTypeElementsResults => {
+    fs.writeFileSync(choiceTypesOutputPath, JSON.stringify(choiceTypeElementsResults, null, 2), 'utf8');
+    console.log(`Wrote file to ${choiceTypesOutputPath}`);
+  })
+  .catch(e => {
+    console.error(e);
+  });

--- a/src/scripts/parseStructureDefinitions.js
+++ b/src/scripts/parseStructureDefinitions.js
@@ -23,11 +23,10 @@ async function main() {
 
     // read the contents of the file
     const structureDef = JSON.parse(fs.readFileSync(f.fullPath, 'utf8'));
-    // QUESTION: should I be using snapshot or differential ?
     structureDef.snapshot.element.forEach(e => {
       const elem = e.id.split('.');
       if (elem.length === 2) {
-        if (e.min === 1) {
+        if (e.min >= 1) {
           mandatoryElements.push(elem[1]);
         }
       }

--- a/src/scripts/parseStructureDefinitions.js
+++ b/src/scripts/parseStructureDefinitions.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const STRUCTURE_DEFINITIONS_BASE_PATH = path.join(__dirname, '../resource-definitions');
+const mandatoryElemsOutputPath = path.resolve(
+  path.join(__dirname, '../compartment-definition/mandatory-elements.json')
+);
+
+/**
+ * Parse the StructureDefinition of resource types supported by this server for mandatory elements
+ * @returns {Object} object whose keys are resourceTypes and values are arrays of strings that are mandatory elements
+ */
+async function main() {
+  const files = fs.readdirSync(STRUCTURE_DEFINITIONS_BASE_PATH).map(f => ({
+    shortName: f.split('.profile')[0],
+    fullPath: path.join(STRUCTURE_DEFINITIONS_BASE_PATH, f)
+  }));
+
+  const mandatoryElementsResults = {};
+
+  files.forEach(f => {
+    let mandatoryElements = [];
+
+    // read the contents of the file
+    const structureDef = JSON.parse(fs.readFileSync(f.fullPath, 'utf8'));
+    // QUESTION: should I be using snapshot or differential ?
+    structureDef.snapshot.element.forEach(e => {
+      const elem = e.id.split('.');
+      if (elem.length === 2) {
+        if (e.min === 1) {
+          mandatoryElements.push(elem[1]);
+        }
+      }
+    });
+    mandatoryElementsResults[structureDef.id] = mandatoryElements;
+  });
+
+  return mandatoryElementsResults;
+}
+
+main()
+  .then(mandatoryElementsResults => {
+    fs.writeFileSync(mandatoryElemsOutputPath, JSON.stringify(mandatoryElementsResults, null, 2), 'utf8');
+    console.log(`Wrote file to ${mandatoryElemsOutputPath}`);
+  })
+  .catch(e => {
+    console.error(e);
+  });

--- a/src/scripts/parseStructureDefinitions.js
+++ b/src/scripts/parseStructureDefinitions.js
@@ -8,6 +8,8 @@ const mandatoryElemsOutputPath = path.resolve(
 
 /**
  * Parse the StructureDefinition of resource types supported by this server for mandatory elements
+ * The StructureDefinitions of each resource type is found in the FHIR R4 spec
+ * For example, the StructureDefinition for Encounter was found here: https://hl7.org/fhir/R4/encounter.profile.json.html
  * @returns {Object} object whose keys are resourceTypes and values are arrays of strings that are mandatory elements
  */
 async function main() {

--- a/src/server/exportWorker.js
+++ b/src/server/exportWorker.js
@@ -15,12 +15,12 @@ const exportQueue = new Queue('export', {
 // This handler pulls down the jobs on Redis to handle
 exportQueue.process(async job => {
   // Payload of createJob exists on job.data
-  const { clientEntry, types, typeFilter, patient, systemLevelExport, patientIds } = job.data;
+  const { clientEntry, types, typeFilter, patient, systemLevelExport, patientIds, elements } = job.data;
   console.log(`export-worker-${process.pid}: Processing Request: ${clientEntry}`);
   await client.connect();
   // Call the existing export ndjson function that writes the files
 
-  const result = await exportToNDJson(clientEntry, types, typeFilter, patient, systemLevelExport, patientIds);
+  const result = await exportToNDJson(clientEntry, types, typeFilter, patient, systemLevelExport, patientIds, elements);
   if (result) {
     console.log(`export-worker-${process.pid}: Completed Export Request: ${clientEntry}`);
   } else {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -231,18 +231,12 @@ function validateExportParams(parameters, reply) {
     elementsArray.forEach(line => {
       // split each of the elements up by a '.' if it has one. If it does, the first part is the resourceType and the second is the element name
       // if there is no '.', we assume that the element is just the element name
-      // TODO: add some sort of check for unsupported elements
       let resourceType = 'all';
       if (line.includes('.')) {
         resourceType = line.split('.')[0];
         if (!supportedResources.includes(resourceType)) {
           unsupportedResourceTypes.push(resourceType);
-        } else {
-          // TODO: do we need to check if an element name exists on the given resourceType ?
         }
-      } else {
-        // TODO: go through all the supported resources and make sure that the element name exists on the resource ?
-        // do we need to do this ? I don't think it's done for other parts of this server
       }
     });
     if (unsupportedResourceTypes.length > 0) {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -26,12 +26,15 @@ const bulkExport = async (request, reply) => {
 
     const types = request.query._type?.split(',') || parameters._type?.split(',');
 
+    const elements = request.query._elements?.split(',') || parameters._elements?.split(',');
+
     // Enqueue a new job into Redis for handling
     const job = {
       clientEntry: clientEntry,
       types: types,
       typeFilter: request.query._typeFilter,
-      systemLevelExport: true
+      systemLevelExport: true,
+      elements: elements
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -70,13 +73,16 @@ const patientBulkExport = async (request, reply) => {
       types = patientResourceTypes;
     }
 
+    const elements = request.query._elements?.split(',') || parameters._elements?.split(',');
+
     // Enqueue a new job into Redis for handling
     const job = {
       clientEntry: clientEntry,
       types: types,
       typeFilter: parameters._typeFilter,
       patient: parameters.patient,
-      systemLevelExport: false
+      systemLevelExport: false,
+      elements: elements
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -123,6 +129,8 @@ const groupBulkExport = async (request, reply) => {
       types = patientResourceTypes;
     }
 
+    const elements = request.query._elements?.split(',') || parameters._elements?.split(',');
+
     // Enqueue a new job into Redis for handling
     const job = {
       clientEntry: clientEntry,
@@ -130,7 +138,8 @@ const groupBulkExport = async (request, reply) => {
       typeFilter: parameters._typeFilter,
       patient: parameters.patient,
       systemLevelExport: false,
-      patientIds: patientIds
+      patientIds: patientIds,
+      elements: elements
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -220,17 +229,50 @@ function validateExportParams(parameters, reply) {
     const unsupportedResourceTypes = [];
     const unsupportedElementTypes = [];
     elementsArray.forEach(line => {
-      let resourceType = null;
+      // split each of the elements up by a '.' if it has one. If it does, the first part is the resourceType and the second is the element name
+      // if there is no '.', we assume that the element is just the element name
+      // TODO: add some sort of check for unsupported elements
+      let resourceType = 'all';
       let elementName;
       if (line.includes('.')) {
         resourceType = line.split('.')[0];
         elementName = line.split('.')[1];
         if (!supportedResources.includes(resourceType)) {
           unsupportedResourceTypes.push(resourceType);
+        } else {
+          // TODO: do we need to check if an element name exists on the given resourceType ?
         }
       } else {
+        elementName = line;
+        // TODO: go through all the supported resources and make sure that the element name exists on the resource ?
+        // do we need to do this ? I don't think it's done for other parts of this server
       }
     });
+    if (unsupportedResourceTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceTypes are not supported for _element param for $export: ${unsupportedResourceTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    } else if (unsupportedElementTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceType and element names are not supported for _element param for $export: ${unsupportedResourceTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    }
   }
 
   if (parameters.patient) {
@@ -246,7 +288,7 @@ function validateExportParams(parameters, reply) {
 
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
-    if (!['_outputFormat', '_type', '_typeFilter', 'patient'].includes(param)) {
+    if (!['_outputFormat', '_type', '_typeFilter', 'patient', '_elements'].includes(param)) {
       unrecognizedParams.push(param);
     }
   });

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -233,17 +233,14 @@ function validateExportParams(parameters, reply) {
       // if there is no '.', we assume that the element is just the element name
       // TODO: add some sort of check for unsupported elements
       let resourceType = 'all';
-      let elementName;
       if (line.includes('.')) {
         resourceType = line.split('.')[0];
-        // elementName = line.split('.')[1];
         if (!supportedResources.includes(resourceType)) {
           unsupportedResourceTypes.push(resourceType);
         } else {
           // TODO: do we need to check if an element name exists on the given resourceType ?
         }
       } else {
-        // elementName = line;
         // TODO: go through all the supported resources and make sure that the element name exists on the resource ?
         // do we need to do this ? I don't think it's done for other parts of this server
       }

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -214,6 +214,25 @@ function validateExportParams(parameters, reply) {
     }
   }
 
+  // add validation for the _elements query param
+  if (parameters._elements) {
+    const elementsArray = parameters._elements.split(',');
+    const unsupportedResourceTypes = [];
+    const unsupportedElementTypes = [];
+    elementsArray.forEach(line => {
+      let resourceType = null;
+      let elementName;
+      if (line.includes('.')) {
+        resourceType = line.split('.')[0];
+        elementName = line.split('.')[1];
+        if (!supportedResources.includes(resourceType)) {
+          unsupportedResourceTypes.push(resourceType);
+        }
+      } else {
+      }
+    });
+  }
+
   if (parameters.patient) {
     const referenceFormat = /^Patient\/[\w-]+$/;
     const errorMessage = 'All patient references must be of the format "Patient/{id}" for the "patient" parameter.';

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -236,14 +236,14 @@ function validateExportParams(parameters, reply) {
       let elementName;
       if (line.includes('.')) {
         resourceType = line.split('.')[0];
-        elementName = line.split('.')[1];
+        // elementName = line.split('.')[1];
         if (!supportedResources.includes(resourceType)) {
           unsupportedResourceTypes.push(resourceType);
         } else {
           // TODO: do we need to check if an element name exists on the given resourceType ?
         }
       } else {
-        elementName = line;
+        // elementName = line;
         // TODO: go through all the supported resources and make sure that the element name exists on the resource ?
         // do we need to do this ? I don't think it's done for other parts of this server
       }

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -131,15 +131,15 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
           resourceType = e.split('.')[0];
           elementName = e.split('.')[1];
           if (Object.keys(choiceTypeElements[resourceType]).length !== 0) {
-            console.log('hello');
             if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
-              console.log('hi hi hi');
               choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
                 const rootElem = elementName.split('[x]')[0];
+                const type = e.charAt(0).toUpperCase() + e.slice(1);
+                console.log(type);
                 if (elementsQueries[resourceType]) {
-                  elementsQueries[resourceType].push(`${rootElem}${e}`);
+                  elementsQueries[resourceType].push(`${rootElem}${type}`);
                 } else {
-                  elementsQueries[resourceType] = [`${rootElem}${e}`];
+                  elementsQueries[resourceType] = [`${rootElem}${type}`];
                 }
               });
             }
@@ -155,10 +155,11 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
               if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
                 choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
                   const rootElem = elementName.split('[x]')[0];
+                  const type = e.charAt(0).toUpperCase() + e.slice(1);
                   if (elementsQueries[resourceType]) {
-                    elementsQueries[resourceType].push(`${rootElem}${e}`);
+                    elementsQueries[resourceType].push(`${rootElem}${type}`);
                   } else {
-                    elementsQueries[resourceType] = [`${rootElem}${e}`];
+                    elementsQueries[resourceType] = [`${rootElem}${type}`];
                   }
                 });
               }

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -13,6 +13,7 @@ const {
 } = require('./mongo.controller');
 const patientRefs = require('../compartment-definition/patient-references');
 const mandatoryElements = require('../compartment-definition/mandatory-elements');
+const choiceTypeElements = require('../compartment-definition/choice-types.json');
 const QueryBuilder = require('@asymmetrik/fhir-qb');
 const { getSearchParameters } = require('@projecttacoma/node-fhir-server-core');
 
@@ -129,7 +130,20 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
         if (e.includes('.')) {
           resourceType = e.split('.')[0];
           elementName = e.split('.')[1];
-          if (elementsQueries[resourceType]) {
+          if (Object.keys(choiceTypeElements[resourceType]).length !== 0) {
+            console.log('hello');
+            if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
+              console.log('hi hi hi');
+              choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
+                const rootElem = elementName.split('[x]')[0];
+                if (elementsQueries[resourceType]) {
+                  elementsQueries[resourceType].push(`${rootElem}${e}`);
+                } else {
+                  elementsQueries[resourceType] = [`${rootElem}${e}`];
+                }
+              });
+            }
+          } else if (elementsQueries[resourceType]) {
             elementsQueries[resourceType].push(elementName);
           } else {
             elementsQueries[resourceType] = [elementName];
@@ -137,7 +151,18 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
         } else {
           elementName = e;
           supportedResources.forEach(resourceType => {
-            if (elementsQueries[resourceType]) {
+            if (Object.keys(choiceTypeElements[resourceType]).length !== 0) {
+              if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
+                choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
+                  const rootElem = elementName.split('[x]')[0];
+                  if (elementsQueries[resourceType]) {
+                    elementsQueries[resourceType].push(`${rootElem}${e}`);
+                  } else {
+                    elementsQueries[resourceType] = [`${rootElem}${e}`];
+                  }
+                });
+              }
+            } else if (elementsQueries[resourceType]) {
               elementsQueries[resourceType].push(elementName);
             } else {
               elementsQueries[resourceType] = [elementName];

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -12,6 +12,7 @@ const {
   findResourcesWithAggregation
 } = require('./mongo.controller');
 const patientRefs = require('../compartment-definition/patient-references');
+const mandatoryElements = require('../compartment-definition/mandatory-elements');
 const QueryBuilder = require('@asymmetrik/fhir-qb');
 const { getSearchParameters } = require('@projecttacoma/node-fhir-server-core');
 
@@ -228,10 +229,15 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
   }
 
   // create elements projection
-  // TODO: add mandatory elements based on the resource type to the projection
   const projection = { _id: 0 };
   if (elements) {
     elements.forEach(elem => {
+      projection[elem] = 1;
+    });
+
+    // add a projection of 1 for mandatory elements for the resourceType as defined by the StructureDefinition of the resourceType
+    // mandatory elements are elements that have min cardinality of 1
+    mandatoryElements[collectionName].forEach(elem => {
       projection[elem] = 1;
     });
   }

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -125,49 +125,52 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
     // create lookup object for _elements parameter
     if (elements) {
       elements.forEach(e => {
-        let resourceType = 'all';
-        let elementName;
+        let elementNames = [];
         if (e.includes('.')) {
-          resourceType = e.split('.')[0];
-          elementName = e.split('.')[1];
-          if (Object.keys(choiceTypeElements[resourceType]).length !== 0) {
-            if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
-              choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
-                const rootElem = elementName.split('[x]')[0];
-                const type = e.charAt(0).toUpperCase() + e.slice(1);
-                console.log(type);
-                if (elementsQueries[resourceType]) {
-                  elementsQueries[resourceType].push(`${rootElem}${type}`);
-                } else {
-                  elementsQueries[resourceType] = [`${rootElem}${type}`];
-                }
-              });
-            }
-          } else if (elementsQueries[resourceType]) {
-            elementsQueries[resourceType].push(elementName);
+          const resourceType = e.split('.')[0];
+          const elementName = e.split('.')[1];
+          if (
+            Object.keys(choiceTypeElements[resourceType]).length !== 0 &&
+            Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)
+          ) {
+            const rootElem = elementName.split('[x]')[0];
+            choiceTypeElements[resourceType][rootElem].forEach(e => {
+              const type = e.charAt(0).toUpperCase() + e.slice(1);
+              elementNames.push(`${rootElem}${type}`);
+            });
           } else {
-            elementsQueries[resourceType] = [elementName];
+            elementNames.push(elementName);
           }
-        } else {
-          elementName = e;
-          supportedResources.forEach(resourceType => {
-            if (Object.keys(choiceTypeElements[resourceType]).length !== 0) {
-              if (Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)) {
-                choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
-                  const rootElem = elementName.split('[x]')[0];
-                  const type = e.charAt(0).toUpperCase() + e.slice(1);
-                  if (elementsQueries[resourceType]) {
-                    elementsQueries[resourceType].push(`${rootElem}${type}`);
-                  } else {
-                    elementsQueries[resourceType] = [`${rootElem}${type}`];
-                  }
-                });
-              }
-            } else if (elementsQueries[resourceType]) {
-              elementsQueries[resourceType].push(elementName);
+
+          elementNames.forEach(e => {
+            if (elementsQueries[resourceType]) {
+              elementsQueries[resourceType].push(e);
             } else {
-              elementsQueries[resourceType] = [elementName];
+              elementsQueries[resourceType] = [e];
             }
+          });
+        } else {
+          supportedResources.forEach(resourceType => {
+            if (
+              Object.keys(choiceTypeElements[resourceType]).length !== 0 &&
+              Object.keys(choiceTypeElements[resourceType]).includes(`${e}[x]`)
+            ) {
+              const rootElem = e.split('[x]')[0];
+              choiceTypeElements[resourceType][`${e}[x]`].forEach(e => {
+                const type = e.charAt(0).toUpperCase() + e.slice(1);
+                elementNames.push(`${rootElem}${type}`);
+              });
+            } else {
+              elementNames.push(e);
+            }
+
+            elementNames.forEach(e => {
+              if (elementsQueries[resourceType]) {
+                elementsQueries[resourceType].push(e);
+              } else {
+                elementsQueries[resourceType] = [e];
+              }
+            });
           });
         }
       });

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -240,6 +240,10 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
     mandatoryElements[collectionName].forEach(elem => {
       projection[elem] = 1;
     });
+
+    // add a projection of 1 for resourceType which we have determined to be a mandatory element for each FHIR resource even though
+    // it is not included in the StructureDefinition
+    projection['resourceType'] = 1;
   }
 
   if (searchParameterQueries) {

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -260,6 +260,24 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
   } else {
     docs = await findResourcesWithQuery({}, collectionName, { projection: projection });
   }
+
+  // add the SUBSETTED tag to the resources returned when the _elements parameter is used
+  if (elements) {
+    docs.map(doc => {
+      if (doc.meta) {
+        if (doc.meta.tag) {
+          doc.meta.tag.push({ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' });
+        } else {
+          doc.meta.tag = [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }];
+        }
+      } else {
+        doc.meta = {
+          tag: [{ code: 'SUBSETTED', system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue' }]
+        };
+      }
+    });
+  }
+
   return { document: docs, collectionName: collectionName };
 };
 

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -134,7 +134,7 @@ const exportToNDJson = async (clientId, types, typeFilter, patient, systemLevelE
             Object.keys(choiceTypeElements[resourceType]).includes(`${elementName}[x]`)
           ) {
             const rootElem = elementName.split('[x]')[0];
-            choiceTypeElements[resourceType][rootElem].forEach(e => {
+            choiceTypeElements[resourceType][`${elementName}[x]`].forEach(e => {
               const type = e.charAt(0).toUpperCase() + e.slice(1);
               elementNames.push(`${rootElem}${type}`);
             });

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -84,15 +84,18 @@ const removeResource = async (id, resourceType) => {
  * Run an aggregation query on the database.
  * @param {*[]} query Mongo aggregation pipeline array.
  * @param {*} resourceType The resource type (collection) to aggregate on.
+ * @param options Passed in aggregation options, in the case of aggregation,
+ * elements that we want to use in a $project
  * @returns Array promise of results.
  */
-const findResourcesWithAggregation = async (query, resourceType) => {
+const findResourcesWithAggregation = async (query, resourceType, options = {}) => {
   /*
   Asymmetrik includes a $facet object to provide user-friendly pagination, which
   is not relevant here since we are applying the Asymmetrik query to the _typeFilter
   parameter. The query is sliced to remove the $facet object from the aggregation pipeline.
   */
   const queryWithoutFacet = query.slice(0, -1);
+  queryWithoutFacet.push({ $project: options });
   const collection = db.collection(resourceType);
   return (await collection.aggregate(queryWithoutFacet)).toArray();
 };

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -188,10 +188,20 @@ describe('check export logic', () => {
     });
 
     describe('_elements tests', () => {
-      test('returns Condition document with only the resourceType when _elements=Condition.resourceType', async () => {
+      test('returns Condition document with only the resourceType and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
         const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['resourceType']);
         expect(docObj.document.length).toEqual(1);
-        expect(docObj.document[0]).toEqual({ resourceType: 'Condition' });
+        expect(docObj.document[0]).toEqual({
+          resourceType: 'Condition',
+          meta: {
+            tag: [
+              {
+                code: 'SUBSETTED',
+                system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationValue'
+              }
+            ]
+          }
+        });
       });
     });
   });

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -188,7 +188,7 @@ describe('check export logic', () => {
     });
 
     describe('_elements tests', () => {
-      test('returns Condition document with only the id, resourceType and subject (mandatory elements for Condition), and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
+      test('returns Condition document with only the id, resourceType and subject (mandatory elements for Condition), and the SUBSETTED tag when _elements=Condition.id', async () => {
         const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['id']);
         expect(docObj.document.length).toEqual(1);
         expect(docObj.document[0]).toEqual({

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -188,11 +188,12 @@ describe('check export logic', () => {
     });
 
     describe('_elements tests', () => {
-      test('returns Condition document with only the resourceType, subject (mandatory element for Condition), and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
-        const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['resourceType']);
+      test('returns Condition document with only the id, resourceType and subject (mandatory elements for Condition), and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
+        const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['id']);
         expect(docObj.document.length).toEqual(1);
         expect(docObj.document[0]).toEqual({
           resourceType: 'Condition',
+          id: 'test-condition',
           subject: {
             reference: 'Patient/testPatient'
           },

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -50,6 +50,12 @@ describe('check export logic', () => {
       const results = buildSearchParamList('Encounter');
       expect(results).toBeDefined();
     });
+
+    test('returns empty record of valid search params for invalid resource type', () => {
+      const results = buildSearchParamList('BiologicallyDerivedProduct');
+      console.log(results);
+      expect(results).toBeDefined();
+    });
   });
 
   describe('exportToNDJson', () => {
@@ -178,6 +184,14 @@ describe('check export logic', () => {
       test('Expect getDocuments to return empty results for 0 patient association (empty Group)', async () => {
         const docObj = await getDocuments('Encounter', undefined, undefined, []);
         expect(docObj.document.length).toEqual(0);
+      });
+    });
+
+    describe('_elements tests', () => {
+      test('returns Condition document with only the resourceType when _elements=Condition.resourceType', async () => {
+        const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['resourceType']);
+        expect(docObj.document.length).toEqual(1);
+        expect(docObj.document[0]).toEqual({ resourceType: 'Condition' });
       });
     });
   });

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -188,11 +188,14 @@ describe('check export logic', () => {
     });
 
     describe('_elements tests', () => {
-      test('returns Condition document with only the resourceType and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
+      test('returns Condition document with only the resourceType, subject (mandatory element for Condition), and the SUBSETTED tag when _elements=Condition.resourceType', async () => {
         const docObj = await getDocuments('Condition', undefined, undefined, undefined, ['resourceType']);
         expect(docObj.document.length).toEqual(1);
         expect(docObj.document[0]).toEqual({
           resourceType: 'Condition',
+          subject: {
+            reference: 'Patient/testPatient'
+          },
           meta: {
             tag: [
               {


### PR DESCRIPTION
# Summary
This PR adds support for the [_elements](https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters) query parameter as defined by the Bulk Data Access IG. Some inspiration for this parameter's implementation was taken from the implementation of the `_elements` FHIR search parameter implementation in the measure-respository-service in [this PR](https://github.com/projecttacoma/measure-repository/pull/81).

## New behavior
Functionality for the `_elements` query parameter is now available! When the `_elements` query parameter is used, the server will return resources with only the elements specified in the parameter and the SUBSETTED tag (see the Bulk Data Access IG for more info). 

## Code changes
- `exportWorker.js` - add `elements` as a parameter to call to `exportToNDJson`
- `export.service.js` - add `_elements` parameter validation to `validateExportParams` function and add `_elements` as a recognized parameter
- `exportToNDJson.js` - add a try/catch to the `buildSearchParamList` function so that it doesn't error out on some resources that the server supports but for some reason do not exist in the node-fhir-server-core parameters (ex. `BiologicallyDerivedProduct`), add `_elements` parameter handling to `exportToNDJson` and `getDocuments`
- `mongo.controller.js` - add projection functionality to `findResourcesWithAggregation` so that we can use the `_elements` parameter with the `_typeFilter` parameter
- `exportToNDJson.test.js` - adds two tests- one for `_elements` handling in `getDocuments` and the other to make sure that `buildSearchParamList` doesn't error out on one of the `supportResources`

# Implementation Questions
- The Bulk Data Access IG defines the `_elements` parameter to include the following SHOULD functionality: "A server is not obliged to return just the requested elements. A server SHOULD always return mandatory elements whether they are requested or not." I do not have this implemented currently. I feel like it is something I should implement; however, it is an interesting question of how useful that may be (and potentially something we suggest in the IG?). I think it's interesting because in my opinion, if we defined mandatory elements to be elements that have a cardinality of 1..1, then there are quite a few and it may defeat the purpose of a potential use case of the `_elements` parameter (i.e., if a user just wanted the ids of all of the Condition resources).
- If JUST the element name is included, are we returning ALL resource types (and only include x where the element name x is included) OR are we returning ONLY resource types where the element name x is included (right now we do the former). 

# Testing guidance
- Please read and consider my implementation questions! 
- `npm run check` 
- `npm start` to spin up the server at `localhost:3001`
- Try lots of different HTTP request combinations! Try all three endpoints (System-level, Patient, Group) and combinations of the `_elements` parameter with other query parameters (`_type`, `patient`, `_typeFilter`, etc.).
- I would try making your own HTTP requests in Insomnia first because it may bring up something that I missed, but I also have the following Insomnia tests attached!

[ElementsParamTesting.json](https://github.com/projecttacoma/bulk-export-server/files/14780950/ElementsParamTesting.json)
