### PR TITLE
Capability statement

### DIFF
--- a/src/config/capabilityStatementResource.json
+++ b/src/config/capabilityStatementResource.json
@@ -36,15 +36,16 @@
   ],
   "kind": "requirements",
   "fhirVersion": "4.0.1",
-  "format": ["json"],
-  "implementationGuide": ["http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"],
+  "format": [
+    "json"
+  ],
+  "implementationGuide": [
+    "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
+  ],
   "rest": [
     {
       "mode": "server",
       "documentation": "These FHIR Operations initiate the generation of data to which the client is authorized -- whether that be all patients, a subset (defined group) of patients, or all available data contained in a FHIR server.\n\nThe FHIR server SHALL limit the data returned to only those FHIR resources for which the client is authorized.\n\nThe FHIR server SHALL support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html). Servers SHALL support GET requests and MAY support POST requests that supply parameters using the FHIR [Parameters Resource](https://www.hl7.org/fhir/parameters.html).",
-      "security": {
-        "description": "Servers are encouraged to implement OAuth 2.0 access management in accordance with the [SMART Backend Services: Authorization Guide](authorization.html).  Implementations MAY include non-RESTful services that use authorization schemes other than OAuth 2.0, such as mutual-TLS or signed URLs."
-      },
       "resource": [
         {
           "type": "Group",

--- a/src/config/capabilityStatementResource.json
+++ b/src/config/capabilityStatementResource.json
@@ -1,0 +1,97 @@
+{
+  "resourceType": "CapabilityStatement",
+  "id": "bulk-data",
+  "text": {
+    "status": "extensions",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>BulkDataIGCapabilityStatement</h2><div><p>The expected capabilities of a Bulk Data Provider actor (e.g., EHR systems, data warehouses, and other clinical and administrative systems that aim to interoperate by sharing large FHIR datasets) which is responsible for providing responses to the queries submitted by a FHIR Bulk Data Client actor. Systems implementing this capability statement should meet the requirements set by the Bulk Data Access Implementation Guide. A FHIR Bulk Data Client has the option of choosing from this list to access necessary data based on use cases and other contextual requirements.</p>\n</div><table><tr><td>Mode</td><td>SERVER</td></tr><tr><td>Description</td><td><div><p>These FHIR Operations initiate the generation of data to which the client is authorized -- whether that be all patients, a subset (defined group) of patients, or all available data contained in a FHIR server.</p>\n<p>The FHIR server SHALL limit the data returned to only those FHIR resources for which the client is authorized.</p>\n<p>The FHIR server SHALL support invocation of this operation using the <a href=\"http://hl7.org/fhir/R4/async.html\">FHIR Asynchronous Request Pattern</a>. Servers SHALL support GET requests and MAY support POST requests that supply parameters using the FHIR <a href=\"https://www.hl7.org/fhir/parameters.html\">Parameters Resource</a>.</p>\n</div></td></tr><tr><td>Transaction</td><td></td></tr><tr><td>System History</td><td></td></tr><tr><td>System Search</td><td></td></tr></table><table><tr><th><b>Resource Type</b></th><th><b>Profile</b></th><th><b title=\"GET a resource (read interaction)\">Read</b></th><th><b title=\"GET all set of resources of the type (search interaction)\">Search</b></th><th><b title=\"PUT a new resource version (update interaction)\">Update</b></th><th><b title=\"POST a new resource (create interaction)\">Create</b></th></tr><tr><td>Group</td><td></td><td></td><td></td><td></td></tr><tr><td>Patient</td><td></td><td></td><td></td><td></td></tr></table></div>"
+  },
+  "url": "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data",
+  "version": "2.0.0",
+  "name": "BulkDataIGCapabilityStatement",
+  "title": "FHIR Bulk Data Access Implementation Guide",
+  "status": "active",
+  "experimental": false,
+  "date": "2021-07-29",
+  "publisher": "HL7 International - FHIR Infrastructure Work Group",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org/Special/committees/fiwg"
+        }
+      ]
+    }
+  ],
+  "description": "The expected capabilities of a Bulk Data Provider actor (e.g., EHR systems, data warehouses, and other clinical and administrative systems that aim to interoperate by sharing large FHIR datasets) which is responsible for providing responses to the queries submitted by a FHIR Bulk Data Client actor. Systems implementing this capability statement should meet the requirements set by the Bulk Data Access Implementation Guide. A FHIR Bulk Data Client has the option of choosing from this list to access necessary data based on use cases and other contextual requirements.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "http://unstats.un.org/unsd/methods/m49/m49.htm",
+          "code": "001"
+        }
+      ]
+    }
+  ],
+  "kind": "requirements",
+  "fhirVersion": "4.0.1",
+  "format": ["json"],
+  "implementationGuide": ["http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"],
+  "rest": [
+    {
+      "mode": "server",
+      "documentation": "These FHIR Operations initiate the generation of data to which the client is authorized -- whether that be all patients, a subset (defined group) of patients, or all available data contained in a FHIR server.\n\nThe FHIR server SHALL limit the data returned to only those FHIR resources for which the client is authorized.\n\nThe FHIR server SHALL support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html). Servers SHALL support GET requests and MAY support POST requests that supply parameters using the FHIR [Parameters Resource](https://www.hl7.org/fhir/parameters.html).",
+      "security": {
+        "description": "Servers are encouraged to implement OAuth 2.0 access management in accordance with the [SMART Backend Services: Authorization Guide](authorization.html).  Implementations MAY include non-RESTful services that use authorization schemes other than OAuth 2.0, such as mutual-TLS or signed URLs."
+      },
+      "resource": [
+        {
+          "type": "Group",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "group-export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export",
+              "documentation": "FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients in specified [Group](https://www.hl7.org/fhir/group.html).\n\nIf a FHIR server supports Group-level data export, it SHOULD support reading and searching for `Group` resource. This enables clients to discover available groups based on stable characteristics such as `Group.identifier`.\n\nThe [Patient Compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html) SHOULD be used as a point of reference for recommended resources to be returned and, where applicable, Patient resources SHOULD be returned. Other resources outside of the patient compartment that are helpful in interpreting the patient data (such as Organization and Practitioner) MAY also be returned."
+            }
+          ]
+        },
+        {
+          "type": "Patient",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient-export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export",
+              "documentation": "FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients.\n\nThe [Patient Compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html) SHOULD be used as a point of reference for recommended resources to be returned and, where applicable, Patient resources SHOULD be returned. Other resources outside of the patient compartment that are helpful in interpreting the patient data (such as Organization and Practitioner) MAY also be returned."
+            }
+          ]
+        }
+      ],
+      "operation": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "name": "export",
+          "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export",
+          "documentation": "FHIR Operation to export data from a FHIR server, whether or not it is associated with a patient. This supports use cases like backing up a server, or exporting terminology data by restricting the resources returned using the `_type` parameter."
+        }
+      ]
+    }
+  ]
+}

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -5,10 +5,12 @@ const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
 const { uploadTransactionOrBatchBundle } = require('../services/bundle.service');
+const { generateCapabilityStatement } = require('../services/metadata.service');
 
 // set bodyLimit to 50mb
 function build(opts) {
   const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
+  app.get('/metadata', generateCapabilityStatement);
   app.get('/$export', bulkExport);
   app.post('/$export', bulkExport);
   app.get('/Patient/$export', patientBulkExport);

--- a/src/services/metadata.service.js
+++ b/src/services/metadata.service.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const capabilityStatementResource = require('../config/capabilityStatementResource.json');
+
+const generateCapabilityStatement = async (request, reply) => {
+  request.log.info(`Metadata.generateCapabilityStatement`);
+
+  reply.code(200);
+  reply.send(capabilityStatementResource);
+};
+
+module.exports = { generateCapabilityStatement };

--- a/src/services/metadata.service.js
+++ b/src/services/metadata.service.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const capabilityStatementResource = require('../config/capabilityStatementResource.json');
 
 const generateCapabilityStatement = async (request, reply) => {


### PR DESCRIPTION
# Summary
Adds a `/metdata` endpoint to the server to display the capability statement. This is mostly so our server does not show a 404 error in ConMan for the Connectathon!

## New behavior
`/metadata` endpoint returns a 200 code and the capability statement JSON found [here](http://hl7.org/fhir/uv/bulkdata/STU2/CapabilityStatement-bulk-data.json.html). I believe it is reflective of our server's capabilities, but not sure if I need to remove or add anything.

## Code changes
- `src/config/capabilityStatementResource.json` - capability statement grabbed from the Bulk Data Access IG
- `src/server/app.js` - add `/metadata` endpoint
- `metadata.service.js` - service for the capability statement `/metadata` endpoint

# Testing guidance
- Make sure this makes sense as a capability statement.
- `npm start`
- Send a GET request through Insomnia (or whatever) to `http://localhost:3000/metadata` and make sure a 200 status code is returned as well as the capability statement.