### PR TITLE
Create Patient Service and Implement CRUD operations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,15 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true,
-        "node": true,
-        "jest": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": 13,
-        "sourceType": "module"
-    },
-    "rules": {
-    }
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 13,
+    "sourceType": "module"
+  },
+  "rules": {},
+  "ignorePatterns": ["ecqm-content-r4-2021"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 coverage
+ecqm-content-r4-2021

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -7,7 +7,7 @@ const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
 const { uploadTransactionOrBatchBundle } = require('../services/bundle.service');
 const { generateCapabilityStatement } = require('../services/metadata.service');
-
+const { patientSearch, patientSearchById, patientCreate, patientUpdate } = require('../services/patient.service');
 // set bodyLimit to 50mb
 function build(opts) {
   const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
@@ -26,6 +26,11 @@ function build(opts) {
   app.post('/Group', groupCreate);
   app.put('/Group/:groupId', groupUpdate);
   app.post('/', uploadTransactionOrBatchBundle);
+  app.get('/Patient/:patientId', patientSearchById);
+  app.get('/Patient', patientSearch);
+  app.post('/Patient', patientCreate);
+  app.put('/Patient/:patientId', patientUpdate);
+
   return app;
 }
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,10 +4,16 @@ const cors = require('@fastify/cors');
 const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/export.service');
 const { checkBulkStatus } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
-const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
+const { groupSearchById, groupSearch, groupCreate, groupUpdate, groupRemove } = require('../services/group.service');
 const { uploadTransactionOrBatchBundle } = require('../services/bundle.service');
 const { generateCapabilityStatement } = require('../services/metadata.service');
-const { patientSearch, patientSearchById, patientCreate, patientUpdate } = require('../services/patient.service');
+const {
+  patientSearch,
+  patientSearchById,
+  patientCreate,
+  patientUpdate,
+  patientRemove
+} = require('../services/patient.service');
 // set bodyLimit to 50mb
 function build(opts) {
   const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
@@ -25,11 +31,13 @@ function build(opts) {
   app.get('/Group', groupSearch);
   app.post('/Group', groupCreate);
   app.put('/Group/:groupId', groupUpdate);
+  app.delete('/Group/:groupId', groupRemove);
   app.post('/', uploadTransactionOrBatchBundle);
   app.get('/Patient/:patientId', patientSearchById);
   app.get('/Patient', patientSearch);
   app.post('/Patient', patientCreate);
   app.put('/Patient/:patientId', patientUpdate);
+  app.delete('/Patient/:patientId', patientRemove);
 
   return app;
 }

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -1,8 +1,10 @@
+const { createSearchsetBundle } = require('../util/bundleUtils');
 const {
   findResourceById,
   findResourcesWithQuery,
   createResource,
-  updateResource
+  updateResource,
+  removeResource
 } = require('../util/mongo.controller');
 const { v4: uuidv4 } = require('uuid');
 
@@ -30,7 +32,7 @@ const groupSearch = async (request, reply) => {
   if (!result.length > 0) {
     reply.code(404).send(new Error('No Group resources were found on the server'));
   }
-  return result;
+  return createSearchsetBundle(result);
 };
 
 /**
@@ -59,9 +61,23 @@ const groupUpdate = async (request, reply) => {
   return updateResource(request.params.groupId, data, 'Group');
 };
 
+/**
+ * Deletes the Group resource with the passed in id. Sends 404 if Group with id passed in is not found.
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const groupRemove = async (request, reply) => {
+  const found = await findResourceById(request.params.groupId, 'Group');
+  if (!found) {
+    reply.code(404).send(new Error(`The requested group ${request.params.groupId} was not found.`));
+  }
+  return removeResource(request.params.groupId, 'Group');
+};
+
 module.exports = {
   groupSearchById,
   groupSearch,
   groupCreate,
-  groupUpdate
+  groupUpdate,
+  groupRemove
 };

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -22,7 +22,6 @@ const groupSearchById = async (request, reply) => {
 
 /**
  * Result of sending a GET request to [base]/Group to find all available Groups.
- * Searches for a Group resource with the passed in id
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
@@ -35,7 +34,7 @@ const groupSearch = async (request, reply) => {
 };
 
 /**
- * Creates an object and generates an id for it regardless of the id passed in
+ * Creates a Group object and generates an id for it regardless of the id passed in.
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
@@ -48,7 +47,7 @@ const groupCreate = async (request, reply) => {
 
 /**
  * Updates the Group resource with the passed in id or creates a new document if
- * no document with passed id is found
+ * no document with passed id is found.
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,8 +1,10 @@
+const { createSearchsetBundle } = require('../util/bundleUtils');
 const {
   findResourceById,
   findResourcesWithQuery,
   createResource,
-  updateResource
+  updateResource,
+  removeResource
 } = require('../util/mongo.controller');
 const { v4: uuidv4 } = require('uuid');
 
@@ -30,7 +32,7 @@ const patientSearch = async (request, reply) => {
   if (!result.length > 0) {
     reply.code(404).send(new Error('No Patient resources were found on the server'));
   }
-  return result;
+  return createSearchsetBundle(result);
 };
 
 /**
@@ -59,9 +61,23 @@ const patientUpdate = async (request, reply) => {
   return updateResource(request.params.patientId, data, 'Patient');
 };
 
+/**
+ * Deletes the Patient resource with the passed in id. Sends 404 if Patient with id passed in not found.
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const patientRemove = async (request, reply) => {
+  const found = await findResourceById(request.params.patientId, 'Patient');
+  if (!found) {
+    reply.code(404).send(new Error(`The requested patient ${request.params.patientId} was not found.`));
+  }
+  return removeResource(request.params.patientId, 'Patient');
+};
+
 module.exports = {
   patientSearchById,
   patientSearch,
   patientCreate,
-  patientUpdate
+  patientUpdate,
+  patientRemove
 };

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -1,0 +1,68 @@
+const {
+  findResourceById,
+  findResourcesWithQuery,
+  createResource,
+  updateResource
+} = require('../util/mongo.controller');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * Result of sending a GET request to [base]/Patient/[id].
+ * Searches for a Patient resource with the passed in id
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const patientSearchById = async (request, reply) => {
+  const result = await findResourceById(request.params.patientId, 'Patient');
+  if (!result) {
+    reply.code(404).send(new Error(`The requested patient ${request.params.patientId} was not found.`));
+  }
+  return result;
+};
+
+/**
+ * Result of sending a GET request to [base]/Patient to find all available Patients.
+ * Searches for a Patient resource with the passed in id
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const patientSearch = async (request, reply) => {
+  const result = await findResourcesWithQuery({}, 'Patient');
+  if (!result.length > 0) {
+    reply.code(404).send(new Error('No patient resources were found on the server'));
+  }
+  return result;
+};
+
+/**
+ * Creates an object and generates an id for it regardless of the id passed in
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const patientCreate = async (request, reply) => {
+  const data = request.body;
+  data['id'] = uuidv4();
+  reply.code(201);
+  return createResource(data, 'Patient');
+};
+
+/**
+ * Updates the patient resource with the passed in id or creates a new document if
+ * no document with passed id is found
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const patientUpdate = async (request, reply) => {
+  const data = request.body;
+  if (data.id !== request.params.patientId) {
+    reply.code(400).send(new Error('Argument id must match request body id for PUT request'));
+  }
+  return updateResource(request.params.patientId, data, 'Patient');
+};
+
+module.exports = {
+  patientSearchById,
+  patientSearch,
+  patientCreate,
+  patientUpdate
+};

--- a/src/services/patient.service.js
+++ b/src/services/patient.service.js
@@ -22,20 +22,19 @@ const patientSearchById = async (request, reply) => {
 
 /**
  * Result of sending a GET request to [base]/Patient to find all available Patients.
- * Searches for a Patient resource with the passed in id
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
 const patientSearch = async (request, reply) => {
   const result = await findResourcesWithQuery({}, 'Patient');
   if (!result.length > 0) {
-    reply.code(404).send(new Error('No patient resources were found on the server'));
+    reply.code(404).send(new Error('No Patient resources were found on the server'));
   }
   return result;
 };
 
 /**
- * Creates an object and generates an id for it regardless of the id passed in
+ * Creates a Patient object and generates an id for it regardless of the id passed in.
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
@@ -47,8 +46,8 @@ const patientCreate = async (request, reply) => {
 };
 
 /**
- * Updates the patient resource with the passed in id or creates a new document if
- * no document with passed id is found
+ * Updates the Patient resource with the passed in id or creates a new document if
+ * no document with passed id is found.
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */

--- a/src/util/bundleUtils.js
+++ b/src/util/bundleUtils.js
@@ -50,4 +50,15 @@ const replaceReferences = entries => {
   return newEntries;
 };
 
-module.exports = { replaceReferences };
+function createSearchsetBundle(entries) {
+  return {
+    resourceType: 'Bundle',
+    meta: { lastUpdated: new Date().toISOString() },
+    id: uuidv4(),
+    type: 'searchset',
+    total: entries.length,
+    entry: entries.map(e => ({ resource: e }))
+  };
+}
+
+module.exports = { replaceReferences, createSearchsetBundle };

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -26,7 +26,7 @@ const createResource = async (data, resourceType) => {
  */
 const findResourceById = async (id, resourceType) => {
   const collection = db.collection(resourceType);
-  return collection.findOne({ id: id });
+  return collection.findOne({ id: id }, { projection: { _id: 0 } });
 };
 
 /**
@@ -37,10 +37,11 @@ const findResourceById = async (id, resourceType) => {
  */
 const findOneResourceWithQuery = async (query, resourceType) => {
   const collection = db.collection(resourceType);
-  return collection.findOne(query);
+  return collection.findOne(query, { projection: { _id: 0 } });
 };
 
-const findResourcesWithQuery = async (query, resourceType, options = {}) => {
+const findResourcesWithQuery = async (query, resourceType, options = { projection: { _id: 0 } }) => {
+  options.projection['_id'] = 0;
   const collection = db.collection(resourceType);
   const results = collection.find(query, options);
   return results.toArray();

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -40,8 +40,13 @@ const findOneResourceWithQuery = async (query, resourceType) => {
   return collection.findOne(query, { projection: { _id: 0 } });
 };
 
+/**
+ * Searches the database for the one or more resources based on a mongo query and returns the data.
+ * @param {Object} query the mongo query to use
+ * @param {string} resourceType type of desired resource, signifies collection resource is stored in
+ * @return {Array} the data of the found documents
+ */
 const findResourcesWithQuery = async (query, resourceType, options = { projection: { _id: 0 } }) => {
-  options.projection['_id'] = 0;
   const collection = db.collection(resourceType);
   const results = collection.find(query, options);
   return results.toArray();

--- a/test/fixtures/testPatient.json
+++ b/test/fixtures/testPatient.json
@@ -1,4 +1,4 @@
 {
-  "resourceType": "Patient",
-  "id": "testPatient"
-}
+    "resourceType": "Patient",
+    "id": "testPatient"
+  }

--- a/test/fixtures/testPatient.json
+++ b/test/fixtures/testPatient.json
@@ -1,4 +1,4 @@
 {
-    "resourceType": "Patient",
-    "id": "testPatient"
-  }
+  "resourceType": "Patient",
+  "id": "testPatient"
+}

--- a/test/fixtures/updatedTestPatient.json
+++ b/test/fixtures/updatedTestPatient.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "Patient",
+  "id": "testPatient",
+  "gender": "female"
+}

--- a/test/services/group.service.test.js
+++ b/test/services/group.service.test.js
@@ -46,7 +46,7 @@ describe('CRUD operations for Group resource', () => {
       .get(`/Group`)
       .expect(200)
       .then(response => {
-        expect(JSON.parse(response.text).length).toEqual(1);
+        expect(response.body.total).toEqual(1);
       });
   });
 
@@ -66,6 +66,20 @@ describe('CRUD operations for Group resource', () => {
 
   test('test update returns 201 when group is not in db', async () => {
     await supertest(app.server).put(`/Group/${TEST_GROUP_ID}`).send(updatedTestGroup).expect(200);
+  });
+
+  test('test delete returns 200 when group in db', async () => {
+    await createTestResource(testGroup, 'Group');
+    await supertest(app.server).delete(`/Group/${TEST_GROUP_ID}`).expect(200);
+  });
+
+  test('test delete returns 404 when group is not in db', async () => {
+    await supertest(app.server)
+      .delete(`/Group/${TEST_GROUP_ID}`)
+      .expect(404)
+      .then(res => {
+        expect(JSON.parse(res.text).message).toEqual(`The requested group ${TEST_GROUP_ID} was not found.`);
+      });
   });
 
   afterEach(async () => {

--- a/test/services/patient.service.test.js
+++ b/test/services/patient.service.test.js
@@ -1,0 +1,75 @@
+const build = require('../../src/server/app');
+const app = build();
+const { client } = require('../../src/util/mongo');
+const supertest = require('supertest');
+const { cleanUpDb, createTestResource } = require('../populateTestData');
+const testPatient = require('../fixtures/testPatient.json');
+const updatedTestPatient = require('../fixtures/updatedTestPatient.json');
+// import queue to close open handles after tests pass
+// TODO: investigate why queues are leaving open handles in this file
+const queue = require('../../src/resources/exportQueue');
+
+const TEST_PATIENT_ID = 'testPatient';
+const INVALID_PATIENT_ID = 'INVALID';
+
+describe('CRUD operations for Group resource', () => {
+  beforeEach(async () => {
+    await client.connect();
+    await app.ready();
+  });
+  test('test create returns 201', async () => {
+    await supertest(app.server).post('/Patient').send(testPatient).expect(201);
+  });
+
+  test('test searchById should return 200 when patient is in db', async () => {
+    await createTestResource(testPatient, 'Patient');
+    await supertest(app.server)
+      .get(`/Patient/${TEST_PATIENT_ID}`)
+      .expect(200)
+      .then(response => {
+        expect(response.body.id).toEqual(TEST_PATIENT_ID);
+      });
+  });
+
+  test('test searchById should return 404 when patient is not in db', async () => {
+    await supertest(app.server)
+      .get(`/Patient/${INVALID_PATIENT_ID}`)
+      .expect(404)
+      .then(response => {
+        expect(JSON.parse(response.text).message).toEqual('The requested patient INVALID was not found.');
+      });
+  });
+
+  test('test search should return 200 when patients are in the db', async () => {
+    await createTestResource(testPatient, 'Patient');
+    await supertest(app.server)
+      .get(`/Patient`)
+      .expect(200)
+      .then(response => {
+        expect(JSON.parse(response.text).length).toEqual(1);
+      });
+  });
+
+  test('test search should return 404 if no patients are in the db', async () => {
+    await supertest(app.server)
+      .get(`/Patient`)
+      .expect(404)
+      .then(response => {
+        expect(JSON.parse(response.text).message).toEqual('No patient resources were found on the server');
+      });
+  });
+
+  test('test update returns 200 when Patient is in db', async () => {
+    await createTestResource(testPatient, 'Patient');
+    await supertest(app.server).put(`/Patient/${TEST_PATIENT_ID}`).send(updatedTestPatient).expect(200);
+  });
+
+  test('test update returns 201 when Patient is not in db', async () => {
+    await supertest(app.server).put(`/Patient/${TEST_PATIENT_ID}`).send(updatedTestPatient).expect(200);
+  });
+
+  afterEach(async () => {
+    await cleanUpDb();
+    await queue.close();
+  });
+});

--- a/test/services/patient.service.test.js
+++ b/test/services/patient.service.test.js
@@ -5,14 +5,12 @@ const supertest = require('supertest');
 const { cleanUpDb, createTestResource } = require('../populateTestData');
 const testPatient = require('../fixtures/testPatient.json');
 const updatedTestPatient = require('../fixtures/updatedTestPatient.json');
-// import queue to close open handles after tests pass
-// TODO: investigate why queues are leaving open handles in this file
 const queue = require('../../src/resources/exportQueue');
 
 const TEST_PATIENT_ID = 'testPatient';
 const INVALID_PATIENT_ID = 'INVALID';
 
-describe('CRUD operations for Group resource', () => {
+describe('CRUD operations for Patient resource', () => {
   beforeEach(async () => {
     await client.connect();
     await app.ready();
@@ -55,16 +53,16 @@ describe('CRUD operations for Group resource', () => {
       .get(`/Patient`)
       .expect(404)
       .then(response => {
-        expect(JSON.parse(response.text).message).toEqual('No patient resources were found on the server');
+        expect(JSON.parse(response.text).message).toEqual('No Patient resources were found on the server');
       });
   });
 
-  test('test update returns 200 when Patient is in db', async () => {
+  test('test update returns 200 when patient is in db', async () => {
     await createTestResource(testPatient, 'Patient');
     await supertest(app.server).put(`/Patient/${TEST_PATIENT_ID}`).send(updatedTestPatient).expect(200);
   });
 
-  test('test update returns 201 when Patient is not in db', async () => {
+  test('test update returns 201 when patient is not in db', async () => {
     await supertest(app.server).put(`/Patient/${TEST_PATIENT_ID}`).send(updatedTestPatient).expect(200);
   });
 

--- a/test/services/patient.service.test.js
+++ b/test/services/patient.service.test.js
@@ -44,7 +44,7 @@ describe('CRUD operations for Patient resource', () => {
       .get(`/Patient`)
       .expect(200)
       .then(response => {
-        expect(JSON.parse(response.text).length).toEqual(1);
+        expect(response.body.total).toEqual(1);
       });
   });
 
@@ -64,6 +64,20 @@ describe('CRUD operations for Patient resource', () => {
 
   test('test update returns 201 when patient is not in db', async () => {
     await supertest(app.server).put(`/Patient/${TEST_PATIENT_ID}`).send(updatedTestPatient).expect(200);
+  });
+
+  test('test delete returns 200 when patient in db', async () => {
+    await createTestResource(testPatient, 'Patient');
+    await supertest(app.server).delete(`/Patient/${TEST_PATIENT_ID}`).expect(200);
+  });
+
+  test('test delete returns 404 when patient is not in db', async () => {
+    await supertest(app.server)
+      .delete(`/Patient/${TEST_PATIENT_ID}`)
+      .expect(404)
+      .then(res => {
+        expect(JSON.parse(res.text).message).toEqual(`The requested patient ${TEST_PATIENT_ID} was not found.`);
+      });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
# Summary

This PR adds endpoints to the bulk-export-server to handle operations related to Patients. Adds operations to create, get, update and delete patients on the server. This PR also adds `Group` delete endpoint. `[host]/Patient` and `[host]/Group` now correctly return a `searchset` as per fhir spec, https://hl7.org/fhir/R4/http.html#search. 


[JIRA Issue](https://jira.mitre.org/browse/TACOSTRAT-1506)

## New behavior

bulk-export-server now has CRUD operations for Patients
- `GET` : `[host]/Patient`
- `GET` : `[host]/Patient/[patientId]`
-  `POST` : `[host]/Patient`
-  `PUT` : `[host]/Patient/[patientID]`
- `DELETE` : `[host]/Patient/[patientID]`

Now has new delete operation for Group
- `DELETE` : `[host]/Group/[groupID]`

Endpoints that find multiple Patients or Groups from the server, `GET` : `[host]/Patient` and `GET` : `[host]/Group`, now return a searchset object instead of a json list of fhir Patient or Group objects.


## Code changes
- `.eslintrc.json` and `.prettierignore` were changed to add `ecqm-content-r4-2021` to the excluded folders because they were causing warnings with eslint and prettier.
- `src/server/app.js` was changed to add the new patient endpoints and new group endpoint to the server.
- `src/services/group.service.js`: updated some comments to be more specific, wrapped the /Group get endpoint in a search set object, added new function for DELETE endpoint.
- `src/services/patient.service.js` was created to implement functions that will interact with the database to fulfill the CRUD operations requested when a user accesses the endpoints for Patients.
- `test/fixtures/updatedTestPatient.json` was created to test the `PUT` endpoint.
- `test/services/patient.service.test.js` are tests for the patient.service.js operations that follows closely from the `group.service.test.js` file.
- `src/util/bundleUtils.js`: created to generate the searchset bundle object that wraps the response from the server for the /Patient and /Group endpoints.
- `src/util/mongo.controller.js`: added a default projection to filter out mongo-generated ids from the server's responses to all operations.
- `test/services/group.service.test.js`: changed /Group test to interact with new searchset response from server

# Testing guidance
- run `npm run check`
- Check that prettier and eslint cause no errors
- Check that all the tests pass
- Test endpoints on Insomnia