### PR TITLE
Kickoff import

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ Alternatively, a POST request (`POST [fhir base]/$export`) can be sent. The expo
 
 For more information on the export endpoints, read this documentation on the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
 
+#### Bulk Status
+
+This server supports the bulk status endpoint in support of the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
+
+Endpoint: `GET [fhir base]/bulkstatus/[client id]`
+
+The server additionally supports a related convenience endpoint which kicks off an `$import` operation for an existing export request. The exported data is selected for import to a data receiver server. This import server location should be specifed with parameters using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) with name `receiver` in the request body. The server will respond with the same bulk status information according to the progress of the existing export workflow.
+
+Endpoint: `POST [fhir base]/bulkstatus/[client id]/kickoff-import`
+
 ## Supported Query Parameters
 
 The server supports the following query parameters:

--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ Endpoint: `GET [fhir base]/$export`
 
 Alternatively, a POST request (`POST [fhir base]/$export`) can be sent. The export parameters must be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body.
 
-For more information on the export endpoints, read this documentation on the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
+For more information on the export endpoints, read this documentation on the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export.html#bulk-data-export-operation-request-flow).
 
 #### Bulk Status
 
-This server supports the bulk status endpoint in support of the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export/index.html#request-flow).
+This server supports the bulk status endpoint in support of the [Export Request Flow](https://hl7.org/fhir/uv/bulkdata/export.html#bulk-data-export-operation-request-flow).
 
 Endpoint: `GET [fhir base]/bulkstatus/[client id]`
 

--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "jest": "^27.3.1",
     "prettier": "^2.4.1",
     "typescript": "^4.4.4"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^axios$": "axios/dist/node/axios.cjs"
+    }
   }
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -19,7 +19,7 @@ function build(opts) {
   app.post('/Patient/$export', patientBulkExport);
   app.get('/Group/:groupId/$export', groupBulkExport);
   app.post('/Group/:groupId/$export', groupBulkExport);
-  app.get('/bulkstatus/:clientId/kickoff-import', kickoffImport);
+  app.post('/bulkstatus/:clientId/kickoff-import', kickoffImport);
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
   app.get('/Group/:groupId', groupSearchById);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -2,7 +2,7 @@ const fastify = require('fastify');
 const cors = require('@fastify/cors');
 
 const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/export.service');
-const { checkBulkStatus } = require('../services/bulkstatus.service');
+const { checkBulkStatus, kickoffImport } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate } = require('../services/group.service');
 const { uploadTransactionOrBatchBundle } = require('../services/bundle.service');
@@ -19,6 +19,7 @@ function build(opts) {
   app.post('/Patient/$export', patientBulkExport);
   app.get('/Group/:groupId/$export', groupBulkExport);
   app.post('/Group/:groupId/$export', groupBulkExport);
+  app.get('/bulkstatus/:clientId/kickoff-import', kickoffImport);
   app.get('/bulkstatus/:clientId', checkBulkStatus);
   app.get('/:clientId/:fileName', returnNDJsonContent);
   app.get('/Group/:groupId', groupSearchById);

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -4,6 +4,7 @@ const exportQueue = require('../resources/exportQueue');
 const patientResourceTypes = require('../compartment-definition/patientExportResourceTypes.json');
 const { createOperationOutcome } = require('../util/errorUtils');
 const { verifyPatientsInGroup } = require('../util/groupUtils');
+const { gatherParams } = require('../util/serviceUtils');
 
 /**
  * Exports data from a FHIR server, whether or not it is associated with a patient.
@@ -296,54 +297,6 @@ function validateExportParams(parameters, reply) {
   }
   return true;
 }
-
-/**
- * Pulls query parameters from both the url query and request body and creates a new parameters map
- * @param {string} method the request method (POST, GET, etc.)
- * @param {Object} query the query terms on the request URL
- * @param {Object} body http request body
- * @param {Object} reply the response object
- * @returns {Object} an object containing a combination of request parameters from both sources
- */
-const gatherParams = (method, query, body, reply) => {
-  if (method === 'POST' && Object.keys(query).length > 0) {
-    reply.code(400).send(
-      createOperationOutcome('Parameters must be specified in a request body for POST requests.', {
-        issueCode: 400,
-        severity: 'error'
-      })
-    );
-  }
-  if (body) {
-    if (!body.resourceType || body.resourceType !== 'Parameters') {
-      reply.code(400).send(
-        createOperationOutcome('Parameters must be specified in a request body of resourceType "Parameters."', {
-          issueCode: 400,
-          severity: 'error'
-        })
-      );
-    }
-  }
-  const params = { ...query };
-  if (body && body.parameter) {
-    body.parameter.reduce((acc, e) => {
-      if (!e.resource) {
-        if (e.name === 'patient') {
-          if (!acc[e.name]) {
-            acc[e.name] = [e.valueReference];
-          } else {
-            acc[e.name].push(e.valueReference);
-          }
-        } else {
-          // For now, all usable params are expected to be stored under one of these fives keys
-          acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode || e.valueReference;
-        }
-      }
-      return acc;
-    }, params);
-  }
-  return params;
-};
 
 /**
  * Checks provided types against the recommended resource types for patient-level export.

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -1,4 +1,3 @@
-
 const { createOperationOutcome } = require('../util/errorUtils');
 
 /**
@@ -9,7 +8,7 @@ const { createOperationOutcome } = require('../util/errorUtils');
  * @param {Object} reply the response object
  * @returns {Object} an object containing a combination of request parameters from both sources
  */
-function gatherParams (method, query, body, reply){
+function gatherParams(method, query, body, reply) {
   if (method === 'POST' && Object.keys(query).length > 0) {
     reply.code(400).send(
       createOperationOutcome('Parameters must be specified in a request body for POST requests.', {

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -1,0 +1,52 @@
+
+const { createOperationOutcome } = require('../util/errorUtils');
+
+/**
+ * Pulls query parameters from both the url query and request body and creates a new parameters map
+ * @param {string} method the request method (POST, GET, etc.)
+ * @param {Object} query the query terms on the request URL
+ * @param {Object} body http request body
+ * @param {Object} reply the response object
+ * @returns {Object} an object containing a combination of request parameters from both sources
+ */
+function gatherParams (method, query, body, reply){
+  if (method === 'POST' && Object.keys(query).length > 0) {
+    reply.code(400).send(
+      createOperationOutcome('Parameters must be specified in a request body for POST requests.', {
+        issueCode: 400,
+        severity: 'error'
+      })
+    );
+  }
+  if (body) {
+    if (!body.resourceType || body.resourceType !== 'Parameters') {
+      reply.code(400).send(
+        createOperationOutcome('Parameters must be specified in a request body of resourceType "Parameters."', {
+          issueCode: 400,
+          severity: 'error'
+        })
+      );
+    }
+  }
+  const params = { ...query };
+  if (body && body.parameter) {
+    body.parameter.reduce((acc, e) => {
+      if (!e.resource) {
+        if (e.name === 'patient') {
+          if (!acc[e.name]) {
+            acc[e.name] = [e.valueReference];
+          } else {
+            acc[e.name].push(e.valueReference);
+          }
+        } else {
+          // For now, all usable params are expected to be stored under one of these fives keys
+          acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode || e.valueReference;
+        }
+      }
+      return acc;
+    }, params);
+  }
+  return params;
+}
+
+module.exports = { gatherParams };

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -7,8 +7,53 @@ const fs = require('fs');
 // import queue to close open handles after tests pass
 // TODO: investigate why queues are leaving open handles in this file
 const queue = require('../../src/resources/exportQueue');
+const clientId = 'testClient';
+
+// describe('kickoffImport logic', () => {
+//   beforeAll(async () => {
+//     await bulkStatusSetup();
+//     fs.mkdirSync(`tmp/${clientId}`, { recursive: true });
+//     fs.closeSync(fs.openSync(`tmp/${clientId}/Patient.ndjson`, 'w'));
+//   });
+
+//   beforeEach(async () => {
+//     await app.ready();
+//   });
+
+//   test('check 200 returned for successful kickoff', async () => {
+//     // TODO: mock data receiver response
+//     await createTestResource(testPatient, 'Patient');
+//     await supertest(app.server)
+//       .post(`/bulkstatus/${clientId}/kickoff-import`)
+//       .send({
+//         resourceType: 'Parameters',
+//         parameter: [
+//           {
+//             name: 'receiver',
+//             valueString: 'http://localhost:3001/4_0_1'
+//           }
+//         ]
+//       })
+//       .expect(200)
+//       .then(response => {
+//         expect(response.headers.expires).toBeDefined();
+//         expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
+//         expect(response.body.output).toEqual([
+//           { type: 'Patient', url: `http://localhost:3000/${clientId}/Patient.ndjson` }
+//         ]);
+//       });
+//   });
+
+//   afterAll(async () => {
+//     await cleanUpDb();
+//     fs.rmSync(`tmp/${clientId}`, { recursive: true, force: true });
+//   });
+
+//   afterEach(async () => {
+//     await queue.close();
+//   });
+// });
 describe('checkBulkStatus logic', () => {
-  const clientId = 'testClient';
 
   beforeAll(async () => {
     await bulkStatusSetup();

--- a/test/services/bulkstatus.service.test.js
+++ b/test/services/bulkstatus.service.test.js
@@ -7,54 +7,8 @@ const fs = require('fs');
 // import queue to close open handles after tests pass
 // TODO: investigate why queues are leaving open handles in this file
 const queue = require('../../src/resources/exportQueue');
-const clientId = 'testClient';
-
-// describe('kickoffImport logic', () => {
-//   beforeAll(async () => {
-//     await bulkStatusSetup();
-//     fs.mkdirSync(`tmp/${clientId}`, { recursive: true });
-//     fs.closeSync(fs.openSync(`tmp/${clientId}/Patient.ndjson`, 'w'));
-//   });
-
-//   beforeEach(async () => {
-//     await app.ready();
-//   });
-
-//   test('check 200 returned for successful kickoff', async () => {
-//     // TODO: mock data receiver response
-//     await createTestResource(testPatient, 'Patient');
-//     await supertest(app.server)
-//       .post(`/bulkstatus/${clientId}/kickoff-import`)
-//       .send({
-//         resourceType: 'Parameters',
-//         parameter: [
-//           {
-//             name: 'receiver',
-//             valueString: 'http://localhost:3001/4_0_1'
-//           }
-//         ]
-//       })
-//       .expect(200)
-//       .then(response => {
-//         expect(response.headers.expires).toBeDefined();
-//         expect(response.headers['content-type']).toEqual('application/json; charset=utf-8');
-//         expect(response.body.output).toEqual([
-//           { type: 'Patient', url: `http://localhost:3000/${clientId}/Patient.ndjson` }
-//         ]);
-//       });
-//   });
-
-//   afterAll(async () => {
-//     await cleanUpDb();
-//     fs.rmSync(`tmp/${clientId}`, { recursive: true, force: true });
-//   });
-
-//   afterEach(async () => {
-//     await queue.close();
-//   });
-// });
 describe('checkBulkStatus logic', () => {
-
+  const clientId = 'testClient';
   beforeAll(async () => {
     await bulkStatusSetup();
     fs.mkdirSync(`tmp/${clientId}`, { recursive: true });


### PR DESCRIPTION
# Summary
Creates a new endpoint on the bulk-export-server to kickoff $import against a specified endpoint on an import server

## New behavior
Server now supports endpoint: `POST [fhir base]/bulkstatus/[client id]/kickoff-import`

## Code changes
- Update README to describe new endpoint
- Update package.json to make axios play nice with jest
- Add new endpoint to app.js and bulkstatus.service.js, including pulling data from the existing bulk status to create the import manifest, appropriate error handling, and appropriate pass-through of headers
- Pull `gatherParams` out of export.service.js into its own shared serviceUtils

# Testing guidance

- `npm run check`
- Start bulk-export-server on port 3001 (and change to port 3001 for both environment variables)
- Start deqm-test-server (on default port 3000, make sure you have the latest with the new $import workflow)
- The Insomnia collection below has a basic set of requests that go through the workflow as follows:
  - Do an $export request on bulk-export-server
  - Check the status of that request at the bulk-export-server bulkstatus endpoint (from the $export response content-location header)
  - Add `/kickoff-import` to the end of the bulkstatus request and use that endpoint to do a POST with a receiver parameter in the body. Example:
`{
  "resourceType": "Parameters",
  "parameter": [
    {
      "name": "receiver",
			"valueString": "http://localhost:3000/4_0_1/$import"
    }
  ]
}`
  - Check the status of the $import request using the deqm-test-server bulkstatus endpoint (from the kickoff-import response content location header)
  - Repeat this workflow for other export options and for error options to make sure the kickoff-import responses makes sense

[kickoff-import-insomnia.json](https://github.com/user-attachments/files/16036594/kickoff-import-insomnia.json)
