### PR TITLE
ValueSet export is Bad Request

### DIFF
--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -1,5 +1,5 @@
 const { addPendingBulkExportRequest, findResourceById } = require('../util/mongo.controller');
-const supportedResources = require('../util/supportedResources');
+const supportedResources = require('../util/supportedResources').filter(r => r !== 'ValueSet'); //exclude ValueSet (may be stored but not exported)
 const exportQueue = require('../resources/exportQueue');
 const patientResourceTypes = require('../compartment-definition/patientExportResourceTypes.json');
 const { createOperationOutcome } = require('../util/errorUtils');

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -62,7 +62,7 @@ const buildSearchParamList = resourceType => {
 const exportToNDJson = async jobOptions => {
   const { clientEntry, types, typeFilter, patient, systemLevelExport, patientIds, elements, byPatient } = jobOptions;
   try {
-    const dirpath = './tmp/';
+    const dirpath = `./tmp/${clientEntry}`;
     fs.mkdirSync(dirpath, { recursive: true });
     let requestTypes = [];
     if (types) {


### PR DESCRIPTION
# Summary
Previously a system export with `_type=ValueSet` had an unexpected file read error. ValueSet should not be allowed to be exported, so 

## New behavior
Any export request with ValueSet as the type specified in the parameters gives a Bad Request response

## Code changes

- export.service update to exclude ValueSet from the types that are supported for export (but not from the types that are supported for storage in the collection creation script)
- exportToNDJson change to properly create the full client id folder to prevent other issues like this

# Testing guidance

- `npm run check`
- `npm run start`
- Insomnia export requests such as `$export?_typeFilter=ValueSet?id=test`, `$export?_elements=ValueSet.id`, `$export?_type=ValueSet` should all return a 400 specifying ValueSet is unsupported.
