### PR TITLE
Date query builder uses name instead of xpath

### DIFF
--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -34,7 +34,7 @@ const buildSearchParamList = resourceType => {
     searchParameterList.forEach(paramDef => {
       // map xpath to parameter description
       {
-        searchParams[paramDef.xpath.substring(paramDef.xpath.indexOf('.') + 1)] = paramDef;
+        searchParams[paramDef.name] = paramDef;
       }
     });
     return searchParams;

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -32,7 +32,7 @@ const buildSearchParamList = resourceType => {
   try {
     const searchParameterList = getSearchParameters(resourceType, '4_0_1');
     searchParameterList.forEach(paramDef => {
-      // map xpath to parameter description
+      // map name to parameter description
       {
         searchParams[paramDef.name] = paramDef;
       }

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -55,7 +55,6 @@ describe('check export logic', () => {
 
     test('returns empty record of valid search params for invalid resource type', () => {
       const results = buildSearchParamList('BiologicallyDerivedProduct');
-      console.log(results);
       expect(results).toBeDefined();
     });
   });
@@ -108,9 +107,9 @@ describe('check export logic', () => {
 
   describe('getDocuments', () => {
     describe('_typeFilter tests', () => {
-      test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z', async () => {
+      test('returns Condition document when _typeFilter=Condition?recorded-date=gt2019-01-03T00:00:00Z', async () => {
         const property = {
-          recordedDate: 'gt2019-01-03T00:00:00Z'
+          'recorded-date': 'gt2019-01-03T00:00:00Z'
         };
         const searchParams = buildSearchParamList('Condition');
         const filter = qb.buildSearchQuery({
@@ -122,11 +121,11 @@ describe('check export logic', () => {
         expect(docObj.document.length).toEqual(1);
       });
 
-      test('returns Condition document when _typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=gt2019-01-03T00:00:00Z', async () => {
+      test('returns Condition document when _typeFilter=Condition?recorded-date=gt2019-01-03T00:00:00Z&onset-date=gt2019-01-03T00:00:00Z', async () => {
         // test for the "&" operator within the query
         const properties = {
-          recordedDate: 'gt2019-01-03T00:00:00Z',
-          onsetDateTime: 'gt2019-01-03T00:00:00Z'
+          'recorded-date': 'gt2019-01-03T00:00:00Z',
+          'onset-date': 'gt2019-01-03T00:00:00Z'
         };
         const searchParams = buildSearchParamList('Condition');
         const filter = qb.buildSearchQuery({
@@ -138,10 +137,10 @@ describe('check export logic', () => {
         expect(docObj.document.length).toEqual(1);
       });
 
-      test('returns no documents when _typeFilter filters out all documents (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z&onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
+      test('returns no documents when _typeFilter filters out all documents (_typeFilter=Condition?recorded-date=gt2019-01-03T00:00:00Z&onset-date=lt2019-01-03T00:00:00Z', async () => {
         const properties = {
-          recordedDate: 'gt2019-01-03T00:00:00Z',
-          onsetDateTime: 'lt2019-01-03T00:00:00Z'
+          'recorded-date': 'gt2019-01-03T00:00:00Z',
+          'onset-date': 'lt2019-01-03T00:00:00Z'
         };
         const searchParams = buildSearchParamList('Condition');
         const filter = qb.buildSearchQuery({
@@ -153,12 +152,12 @@ describe('check export logic', () => {
         expect(docObj.document.length).toEqual(0);
       });
 
-      test('returns Condition document when _typeFilter has "or" condition (_typeFilter=Condition?recordedDate=gt2019-01-03T00:00:00Z,onsetDateTime=lt2019-01-03T00:00:00Z', async () => {
+      test('returns Condition document when _typeFilter has "or" condition (_typeFilter=Condition?recorded-date=gt2019-01-03T00:00:00Z,onset-date=lt2019-01-03T00:00:00Z', async () => {
         const recordedDateProperty = {
-          recordedDate: 'gt2019-01-03T00:00:00Z'
+          'recorded-date': 'gt2019-01-03T00:00:00Z'
         };
         const onsetDateTimeProperty = {
-          onsetDateTime: 'lt2019-01-03T00:00:00Z'
+          'onset-date': 'lt2019-01-03T00:00:00Z'
         };
         const searchParams = buildSearchParamList('Condition');
         const recordedDateFilter = qb.buildSearchQuery({


### PR DESCRIPTION
# Summary
This PR fixes some `_typeFilter` functionality that we had slightly incorrect for mostly date search parameters. Now we can use the correct search parameters such as `Encounter.onset-date`.

## New behavior
We now properly map search parameters to their xpath so that fhir-qb can properly build a search query. Before, the user could only use _typeFilter queries with the xpath, such as `Encounter.onsetDateTime`, when the correct search is `Encounter.onset-date`. This was simply a matter of making sure the parameterDefinitions had the correct keys when being passed into `buildSearchQuery`.

## Code changes
- `src/util/exportToNDJson.js` - make sure the search param keys are the name 
- `test/util/exportToNDJson.js` - change unit tests to have proper _typeFilter search parameters

# Testing guidance
- `npm run check`
- `npm run start`
- Either use Insomnia to test _typeFilter ... OR (even better!) use the [bulk-export-app](https://github.com/projecttacoma/bulk-export-app) to make testing even easier (yay Cooper!)
- Keep in mind that search parameters of type date that map to attributes of type period (ex. `Encounter.date`) will still not work as expected. This still needs to be addressed in our fork of `node-fhir-server-core` and there is a task for that in the BL!