### PR TITLE
Updates for validation

### DIFF
--- a/synthea/qpp_qicore.yaml
+++ b/synthea/qpp_qicore.yaml
@@ -1,5 +1,5 @@
 ---
-name: QI Core - 130 minimal and QPP
+name: QI Core - QPP
 applicability: true
 
 customValueSets:
@@ -119,7 +119,7 @@ actions:
           profiles:
             - http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-devicerequest
         fields:
-          - location: DeviceRequest.code.reference
+          - location: DeviceRequest.codeReference.reference
             value: $findRef([Device])
           - location: DeviceRequest.authoredOn
             value: $getField([Device.manufactureDate]) # manufacture time is set 3 weeks before device model's start, so this is close enough
@@ -127,6 +127,8 @@ actions:
             value: completed
           - location: DeviceRequest.intent
             value: order
+          - location: DeviceRequest.subject.reference
+            value: $findRef([Patient])
       # Creating one AdverseEvent per patient
       - resourceType: AdverseEvent
         based_on:
@@ -136,6 +138,10 @@ actions:
         fields:
           - location: AdverseEvent.event.coding
             value: $randomCode([http://hl7.org/fhir/ValueSet/adverse-event-type]) # may change in future to use a smaller subset of the ValueSet
+          - location: AdverseEvent.subject.reference
+            value: $findRef([Patient])
+          - location: AdverseEvent.actuality
+            value: $randomCode([http://hl7.org/fhir/ValueSet/adverse-event-actuality,code])
       # Creating one Communication per patient
       - resourceType: Communication
         based_on:
@@ -177,3 +183,6 @@ actions:
             value: $randomCode([http://hl7.org/fhir/ValueSet/task-code]) # randomize based on values available
           - location: Task.executionPeriod
             value: $getField([Procedure.performed])
+          - location: Task.intent
+            value: $randomCode([http://hl7.org/fhir/ValueSet/task-intent,code])
+            


### PR DESCRIPTION
# Summary
Update the qpp_qicore.yaml file to pass qicore validation

## New behavior
Generated synthea files pass validation (with a few potential exceptions).

## Code changes
- Adds or updates flexporter instructions for DeviceRequest, AdverseEvent, and Task

# Testing guidance
1.	Create large set of patients using qpp mapping file from https://github.com/projecttacoma/bulk-export-server/pull/52
a.	Use the randomcode_updates branch or main if https://github.com/synthetichealth/synthea/pull/1527 has been merged
b.	Follow additional instructions from the bulk PR above
c.	Set exporter.fhir.us_core_version = 3.1.1 in the synthea.properties file
d.	Use -p to specify the number of patients, i.e. ./run_synthea -fm ../../bulk-export-server/synthea/qpp_qicore.yaml -p 10


2.	Use HAPI FHIR validator to validate the patients.
a.	Use https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases/latest/download/validator_cli.jar
b.	Run with java -jar validator_cli.jar synthea/output/fhir/ -ig http://hl7.org/fhir/us/qicore/ImplementationGuide/hl7.fhir.us.qicore%7C4.1.1 -extension any -display-issues-are-warnings -sct us

Most issues are solved by the settings above, but some remaining issues that don’t effect calculation may include:
i.	"Unknown code 'X9999-"* from the loinc code set