### PR TITLE
OR Multiple _typeFilters

### DIFF
--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -229,7 +229,9 @@ function validateExportParams(parameters, reply) {
   }
 
   if (parameters._typeFilter) {
-    const typeFilterArray = parameters._typeFilter.split(',');
+    const typeFilterArray = Array.isArray(parameters._typeFilter)
+      ? parameters._typeFilter
+      : parameters._typeFilter.split(',');
     const unsupportedTypeFilterTypes = [];
     typeFilterArray.forEach(line => {
       const resourceType = line.substring(0, line.indexOf('?'));

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -78,7 +78,7 @@ const exportToNDJson = async jobOptions => {
     const valueSetQueries = {};
     if (typeFilter) {
       // subqueries may be joined together with a comma for a logical "or"
-      const tyq = typeFilter.split(',');
+      const tyq = Array.isArray(typeFilter) ? typeFilter : typeFilter.split(',');
       // loop over each subquery and extract all search params, which are joined via the "&" operator
       // each subquery is of the format <resource type>?<query>
       tyq.forEach(query => {
@@ -104,6 +104,7 @@ const exportToNDJson = async jobOptions => {
               valueSetQueries[resourceType] = { [property]: [propertyValue] };
             }
           } else {
+            // TODO: this gets overwritten for subqueries with "&" operators
             subqueries[property] = propertyValue;
           }
         });

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -77,7 +77,7 @@ const exportToNDJson = async jobOptions => {
     const searchParameterQueries = {};
     const valueSetQueries = {};
     if (typeFilter) {
-      // subqueries may be joined together with a comma for a logical "or"
+      // subqueries may be joined together with a comma or as an array for a logical "or"
       const tyq = Array.isArray(typeFilter) ? typeFilter : typeFilter.split(',');
       // loop over each subquery and extract all search params, which are joined via the "&" operator
       // each subquery is of the format <resource type>?<query>

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -27,6 +27,10 @@ const mockTypeFilter = 'Patient?maritalStatus:in=http://example.com/example-valu
 
 const complexMockTypeFilter =
   'Patient?maritalStatus:in=http://example.com/example-valueset-1,Encounter?type:in=http://example.com/example-valueset-1,ServiceRequest?code:in=http://example.com/example-valueset-1';
+const mockOrTypeFilter = [
+  'Patient?maritalStatus:in=http://example.com/example-valueset-1',
+  'Encounter?type:in=http://example.com/example-valueset-1'
+];
 const expectedFileNameEncounter = './tmp/123456/Encounter.ndjson';
 const expectedFileNameServiceRequest = './tmp/123456/ServiceRequest.ndjson';
 const typeFilterWOValueSet = 'Procedure?type:in=http';
@@ -81,6 +85,11 @@ describe('check export logic', () => {
       expect(fs.existsSync(expectedFileName)).toBe(true);
       expect(fs.existsSync(expectedFileNameEncounter)).toBe(true);
       expect(fs.existsSync(expectedFileNameServiceRequest)).toBe(true);
+    });
+    test('Expect folder created and export successful when Array _typeFilter parameter is retrieved from request', async () => {
+      await exportToNDJson({ clientEntry: clientId, type: mockType, typeFilter: mockOrTypeFilter });
+      expect(fs.existsSync(expectedFileName)).toBe(true);
+      expect(fs.existsSync(expectedFileNameEncounter)).toBe(true);
     });
     test('Expect folder created and export to fail when _typeFilter parameter is retrieved from request and contains an invalid param', async () => {
       // Note: invalid types are checked in the export service


### PR DESCRIPTION
# Summary
This PR ensures that our implementation of the `_typeFilter` $export Query Parameter aligns with the [Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#_typefilter-query-parameter). Two or more `_typeFilter` Query Parameters are OR'd together when provided in an export request.

## New behavior
- _typeFilter is now aligned with the IG: "When more than one _typeFilter parameter is provided with a query for the same resource type, the server SHALL include resources of that resource type that meet the criteria in any of the parameters (a logical "or")."

## Code changes
- `src/service/export.service.js` - checks if `_typeFilter` is already an array 
- `src/util/exportToNDJson.js` - checks if `_typeFilter` is already an array, added a TODO comment for addressing ANDs within a `_typeFilter` query (we have a separate backlog task for this)
- `test/util/exportToNDJson.test.js` - added unit test for `_typeFilter` array

# Testing guidance
- `npm run db:reset`
- `npm run upload-bundles`
- `npm start`
- Try out different `_typeFilter` queries in Insomnia and make sure they work as expected! Example request collection for Insomnia is attached.

[typeFilterUpdate.json](https://github.com/user-attachments/files/18113499/typeFilterUpdate.json)
