### PR TITLE
organizeOutputBy=Patient query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,19 @@ Endpoint: `POST [fhir base]/bulkstatus/[client id]/kickoff-import`
 
 The server supports the following query parameters:
 
+From the [2.0.0 ci-build version of the Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters):
+
 - `_type`: Filters the response to only include resources of the specified resource type(s)
   - If omitted, system-level requests will return all resources supported by the server within the scope of the client authorization
   - For Patient- and Group-level requests, the [Patient Compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html) is used as a point of reference for filtering the resource types that are returned.
 - `_outputFormat`: The server supports the following formats: `application/fhir+ndjson`, `application/ndjson+fhir`, `application/ndjson`, `ndjson`
 - `_typeFilter`: Filters the response to only include resources that meet the criteria of the specified comma-delimited FHIR REST queries. Returns an error for queries specified by the client that are unsupported by the server. Supports queries on the ValueSets (`type:in`, `code:in`, etc.) of a given resource type.
 - `patient`: Only applicable to POST requests for group-level and patient-level requests. When provided, the server SHALL NOT return resources in the patient compartment definition belonging to patients outside the list. Can support multiple patient references in a single request.
-- `_bySubject`: Only applicable for group-level and patient-level requests. Creates export results, separating resources into files based on what subject they are associated with (rather than based on type). The only `_bySubject` value supported is `Patient`. This will result in an ndjson file for each patient in the returned data. If the `_type` parameter is used in conjunction with this parameter, `Patient` must be one of the types included in the passed value list.
 - `_elements`: Filters the content of the responses to omit unlisted, non-mandatory elements from the resources returned. These elements should be provided in the form `[resource type].[element name]` (e.g., `Patient.id`) which only filters the contents of those specified resources or in the form `[element name]` (e.g., `id`) which filters the contents of all of the returned resources.
+
+From the [2.0.0 ci-build version of the argo24 branch of the Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#query-parameters):
+
+- `organizeOutputBy`: Applicable for all types of export requests. Creates export results, separating resources into files based on what resourceType they are to be organized by. The only `organizeOutputBy` value supported currently is `Patient`. This will result in an ndjson file for each patient in the returned data. If the `_type` parameter is used in conjunction with this parameter, `Patient` must be one of the types included in the passed value lists.
 
 #### `_elements` Query Parameter
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ From the [2.0.0 ci-build version of the Bulk Data Access IG](https://build.fhir.
 
 From the [2.0.0 ci-build version of the argo24 branch of the Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#query-parameters):
 
-- `organizeOutputBy`: Applicable for all types of export requests. Creates export results, separating resources into files based on what resourceType they are to be organized by. The only `organizeOutputBy` value supported currently is `Patient`. This will result in an ndjson file for each patient in the returned data. If the `_type` parameter is used in conjunction with this parameter, `Patient` must be one of the types included in the passed value lists.
+- `organizeOutputBy`: Applicable for all types of export requests. Creates export results, separating resources into files based on what resourceType they are to be organized by. The only `organizeOutputBy` value supported currently is `Patient`. This will result in an ndjson file for each patient in the returned data. If the `_type` parameter is used in conjunction with this parameter, `Patient` must be one of the types included in the passed value lists. Note: in this server's implementation, resources that would otherwise be included in the export, but do not have references to resource type `Patient` are omitted from the export, following guidance from the IG's [Bulk Data Output File Organization](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#bulk-data-output-file-organization).
 
 #### `_elements` Query Parameter
 

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -23,9 +23,18 @@ const bulkExport = async (request, reply) => {
   }
   if (validateExportParams(parameters, reply)) {
     request.log.info('Base >>> $export');
-    const clientEntry = await addPendingBulkExportRequest();
+    const clientEntry = await addPendingBulkExportRequest(parameters.organizeOutputBy === 'Patient');
 
-    const types = parameters._type?.split(',');
+    let types = request.query._type?.split(',') || parameters._type?.split(',');
+    // if parameters.organizeOutputBy=Patient, then we want to pre filter the types that could
+    // have patient references like we do for Patient level export
+    if (parameters.organizeOutputBy === 'Patient') {
+      if (types) {
+        types = filterPatientResourceTypes(request, reply, types);
+      } else {
+        types = patientResourceTypes;
+      }
+    }
 
     const elements = parameters._elements?.split(',');
 

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -21,14 +21,6 @@ const bulkExport = async (request, reply) => {
       })
     );
   }
-  if (parameters._bySubject) {
-    reply.code(400).send(
-      createOperationOutcome('The "_bySubject" parameter cannot be used in a system-level export request.', {
-        issueCode: 400,
-        severity: 'error'
-      })
-    );
-  }
   if (validateExportParams(parameters, reply)) {
     request.log.info('Base >>> $export');
     const clientEntry = await addPendingBulkExportRequest();
@@ -44,7 +36,7 @@ const bulkExport = async (request, reply) => {
       typeFilter: request.query._typeFilter,
       systemLevelExport: true,
       elements: elements,
-      byPatient: parameters._bySubject === 'Patient'
+      byPatient: parameters.organizeOutputBy === 'Patient'
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -74,7 +66,7 @@ const patientBulkExport = async (request, reply) => {
       await validatePatientReferences(parameters.patient, reply);
     }
     request.log.info('Patient >>> $export');
-    const clientEntry = await addPendingBulkExportRequest(parameters._bySubject === 'Patient');
+    const clientEntry = await addPendingBulkExportRequest(parameters.organizeOutputBy === 'Patient');
 
     let types = request.query._type?.split(',') || parameters._type?.split(',');
     if (types) {
@@ -93,7 +85,7 @@ const patientBulkExport = async (request, reply) => {
       patient: parameters.patient,
       systemLevelExport: false,
       elements: elements,
-      byPatient: parameters._bySubject === 'Patient'
+      byPatient: parameters.organizeOutputBy === 'Patient'
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -132,7 +124,7 @@ const groupBulkExport = async (request, reply) => {
       return splitRef[splitRef.length - 1];
     });
 
-    const clientEntry = await addPendingBulkExportRequest(parameters._bySubject === 'Patient');
+    const clientEntry = await addPendingBulkExportRequest(parameters.organizeOutputBy === 'Patient');
     let types = request.query._type?.split(',') || parameters._type?.split(',');
     if (types) {
       types = filterPatientResourceTypes(request, reply, types);
@@ -151,7 +143,7 @@ const groupBulkExport = async (request, reply) => {
       systemLevelExport: false,
       patientIds: patientIds,
       elements: elements,
-      byPatient: parameters._bySubject === 'Patient'
+      byPatient: parameters.organizeOutputBy === 'Patient'
     };
     await exportQueue.createJob(job).save();
     reply.code(202).header('Content-location', `${process.env.BULK_BASE_URL}/bulkstatus/${clientEntry}`).send();
@@ -183,9 +175,9 @@ function validateExportParams(parameters, reply) {
     }
   }
 
-  if (parameters._bySubject && parameters._bySubject !== 'Patient') {
+  if (parameters.organizeOutputBy && parameters.organizeOutputBy !== 'Patient') {
     reply.code(400).send(
-      createOperationOutcome(`Server does not support the _bySubject parameter for values other than Patient.`, {
+      createOperationOutcome(`Server does not support the organizeOutputBy parameter for values other than Patient.`, {
         issueCode: 400,
         severity: 'error'
       })
@@ -215,12 +207,12 @@ function validateExportParams(parameters, reply) {
         );
       return false;
     }
-    if (parameters._bySubject === 'Patient' && !requestTypes.includes('Patient')) {
+    if (parameters.organizeOutputBy === 'Patient' && !requestTypes.includes('Patient')) {
       reply
         .code(400)
         .send(
           createOperationOutcome(
-            `When _type is specified with _bySubject Patient, the Patient type must be included in the _type parameter.`,
+            `When _type is specified with organizeOutputBy Patient, the Patient type must be included in the _type parameter.`,
             { issueCode: 400, severity: 'error' }
           )
         );
@@ -314,7 +306,7 @@ function validateExportParams(parameters, reply) {
 
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
-    if (!['_outputFormat', '_type', '_typeFilter', 'patient', '_elements', '_bySubject'].includes(param)) {
+    if (!['_outputFormat', '_type', '_typeFilter', 'patient', '_elements', 'organizeOutputBy'].includes(param)) {
       unrecognizedParams.push(param);
     }
   });

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -299,7 +299,7 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
   let vsQuery = {};
   // Create patient id query (for Group export only)
   if (patientIds) {
-    if (patientIds.length == 0) {
+    if (patientIds.length === 0) {
       // if no patients in group, return no documents
       return { document: [], collectionName: collectionName };
     }

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -212,7 +212,7 @@ const exportToNDJson = async jobOptions => {
           resourceType: 'Parameters',
           parameter: [
             {
-              name: 'subject',
+              name: 'header',
               valueReference: {
                 reference: `Patient/${patientId}`
               }

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -101,10 +101,6 @@ describe('check export logic', () => {
       await exportToNDJson({ clientEntry: clientId, type: mockType, typeFilter: typeFilterWOValueSet });
       expect(fs.existsSync(expectedFileNameWOValueSet)).toBe(false);
     });
-    test('Expect folder created and export successful when _bySubject parameter is retrieved from request', async () => {
-      await exportToNDJson({ clientEntry: clientId, types: mockType, typeFilter: mockTypeFilter, byPatient: true });
-      expect(fs.existsSync('./tmp/123456/testPatient.ndjson')).toBe(true);
-    });
   });
 
   describe('patientsQueryForType', () => {

--- a/test/util/exportToNDJson.test.js
+++ b/test/util/exportToNDJson.test.js
@@ -101,6 +101,10 @@ describe('check export logic', () => {
       await exportToNDJson({ clientEntry: clientId, type: mockType, typeFilter: typeFilterWOValueSet });
       expect(fs.existsSync(expectedFileNameWOValueSet)).toBe(false);
     });
+    test('Expect folder created and export successful when organizeOutputBy=Patient parameter is retrieved from request', async () => {
+      await exportToNDJson({ clientEntry: clientId, types: mockType, typeFilter: mockTypeFilter, byPatient: true });
+      expect(fs.existsSync('./tmp/123456/testPatient.ndjson')).toBe(true);
+    });
   });
 
   describe('patientsQueryForType', () => {


### PR DESCRIPTION
# Summary
This PR reworks the $export operation `_bySubject=Patient` query parameter to align with the [Argonaut Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/export.html#query-parameters)'s `organizeOutputBy` query parameter.

## New behavior
The `organizeOutputBy` query parameter is now implemented for resourceType Patient. Only `organizeOutputBy=Patient` is implemented. This query parameter works for all $export types- system-level, Patient, and Group. Also removes the `_bySubject=Patient` functionality.

## Code changes
- `README.md` - replaces `_bySubject` query parameter with `organizeOutputBy`
- `src/services/export.service.js` - `_bySubject` -> `organizeOutputBy`
- `test/services/export.service.test.js` - adds unit tests

# Testing guidance
- `npm run check` 
- `npm run start`
- Use the attached Insomnia collection for testing.
- In addition to the Insomnia collection, use the [bulk-export-app](https://github.com/projecttacoma/bulk-export-app)'s `organizeOutputBy=Patient` UI switch:
    - `npm run dev` in `bulk-export-app`
    - Navigate to http://localhost:3001
    - Use http://localhost:3000 for the bulk-export-server input
 - Make sure all references to `_bySubject` have been removed

[organizeOutputByTests.json](https://github.com/user-attachments/files/18741828/organizeOutputByTests.json)
