### PR TITLE
Criteria groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Alternatively, a POST request (`POST [fhir base]/Patient/$export`) can be sent. 
 
 #### All Patients in a Group
 
-FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients that belong to a defined Group resource.
+FHIR Operation to obtain a detailed set of FHIR resources of diverse resource types pertaining to all patients that belong to a defined Group resource. In addition to an actualized group with specifically defined membership, this can also be applied to a criteria based group (as defined in the [Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/group.html#bulk-cohort-api)), which uses expressions to define membership. For a criteria based group, the group membership will be actualized at the time of `$export`.
 
 Endpoint: `GET [fhir base]/Group/[id]/$export`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "fastify": "^4.27.0",
         "fastify-plugin": "^3.0.0",
         "fhir-spec-tools": "^0.3.0",
+        "lodash": "^4.17.21",
         "mongodb": "^4.1.3",
         "pino-pretty": "^7.1.0",
         "supertest": "^6.1.6",
@@ -7979,7 +7980,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fastify": "^4.27.0",
     "fastify-plugin": "^3.0.0",
     "fhir-spec-tools": "^0.3.0",
+    "lodash": "^4.17.21",
     "mongodb": "^4.1.3",
     "pino-pretty": "^7.1.0",
     "supertest": "^6.1.6",

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -4,7 +4,7 @@ const exportQueue = require('../resources/exportQueue');
 const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
 const patientResourceTypes = Object.keys(patientAttributePaths);
 const { createOperationOutcome } = require('../util/errorUtils');
-const { verifyPatientsInGroup } = require('../util/groupUtils');
+const { verifyPatientsInGroup, actualizeGroup } = require('../util/groupUtils');
 const { gatherParams } = require('../util/serviceUtils');
 
 /**
@@ -126,8 +126,15 @@ const groupBulkExport = async (request, reply) => {
       reply.code(404).send(new Error(`The requested group ${request.params.groupId} was not found.`));
       return;
     }
+    let members;
+    if (!group.actual) {
+      members = actualizeGroup(group);
+    } else {
+      members = group.member.map(m => m.entity.reference);
+    }
+
     if (parameters.patient) {
-      verifyPatientsInGroup(parameters.patient, group, reply);
+      verifyPatientsInGroup(parameters.patient, group.id, members, reply);
     }
     const patientIds = group.member.map(m => {
       const splitRef = m.entity.reference.split('/');

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -128,7 +128,7 @@ const groupBulkExport = async (request, reply) => {
     }
     let members;
     if (!group.actual) {
-      members = actualizeGroup(group);
+      members = await actualizeGroup(group);
     } else {
       members = group.member.map(m => m.entity.reference);
     }
@@ -136,8 +136,8 @@ const groupBulkExport = async (request, reply) => {
     if (parameters.patient) {
       verifyPatientsInGroup(parameters.patient, group.id, members, reply);
     }
-    const patientIds = group.member.map(m => {
-      const splitRef = m.entity.reference.split('/');
+    const patientIds = members.map(m => {
+      const splitRef = m.split('/');
       return splitRef[splitRef.length - 1];
     });
 

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -248,7 +248,6 @@ const exportToNDJson = async jobOptions => {
  * @returns {Object} An object containing all data from the given collection name as well as the collection name
  */
 const getDocuments = async (collectionName, searchParameterQueries, valueSetQueries, patientIds, elements) => {
-  console.log(`?????? GetDocuments ${JSON.stringify(searchParameterQueries)}`);
   let docs = [];
   let patQuery = {};
   let vsQuery = {};
@@ -290,7 +289,6 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
   }
 
   if (searchParameterQueries) {
-    console.log(`!!! searchParameterQueries !!! ${JSON.stringify(searchParameterQueries)}`);
     docs = searchParameterQueries.map(async q => {
       let query = q;
       // wherever we have a $match, we need to add another "and" operator containing the ValueSet and/or patient query
@@ -418,10 +416,10 @@ const patientsQueryForType = async function (patientIds, type) {
 /**
  * Adds valueSet and searchParameter queries based on a query's typeFilter value
  * @param {string} typeFilter the type filter query from the request
+ * @param {Object} searchParameterQueries mongo queries for search parameters
  * @param {Object} valueSetQueries mongo queries for valuesets
- * @param {string} searchParameterQueries mongo queries for search parameters
  */
-const addTypeFilter = function (typeFilter, valueSetQueries, searchParameterQueries) {
+const addTypeFilter = function (typeFilter, searchParameterQueries, valueSetQueries) {
   // subqueries may be joined together with a comma or as an array for a logical "or"
   const tyq = Array.isArray(typeFilter) ? typeFilter : typeFilter.split(',');
   // loop over each subquery and extract all search params, which are joined via the "&" operator

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -416,7 +416,7 @@ const patientsQueryForType = async function (patientIds, type) {
 };
 
 /**
- * Adds valueSet ans searchParameter queries based on a query's typeFilter value
+ * Adds valueSet and searchParameter queries based on a query's typeFilter value
  * @param {string} typeFilter the type filter query from the request
  * @param {Object} valueSetQueries mongo queries for valuesets
  * @param {string} searchParameterQueries mongo queries for search parameters

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -77,53 +77,7 @@ const exportToNDJson = async jobOptions => {
     const searchParameterQueries = {};
     const valueSetQueries = {};
     if (typeFilter) {
-      // subqueries may be joined together with a comma or as an array for a logical "or"
-      const tyq = Array.isArray(typeFilter) ? typeFilter : typeFilter.split(',');
-      // loop over each subquery and extract all search params, which are joined via the "&" operator
-      // each subquery is of the format <resource type>?<query>
-      tyq.forEach(query => {
-        const resourceType = query.substring(0, query.indexOf('?'));
-        // build mapping of search parameters for the given resource type
-        const searchParams = buildSearchParamList(resourceType);
-        // extract all properties that may be part of the same subquery via the "&" operator
-        const properties = query.substring(query.indexOf('?') + 1).split('&');
-        // create mapping of properties to their values within the given subquery
-        const subqueries = {};
-        properties.forEach(p => {
-          const property = p.substring(0, p.indexOf('='));
-          const propertyValue = p.substring(p.indexOf('=') + 1);
-          // type:in, code:in, etc.
-          if (property.endsWith(':in')) {
-            if (valueSetQueries[resourceType]) {
-              if (valueSetQueries[resourceType][property]) {
-                valueSetQueries[resourceType][property].push(propertyValue);
-              } else {
-                valueSetQueries[resourceType][property] = [propertyValue];
-              }
-            } else {
-              valueSetQueries[resourceType] = { [property]: [propertyValue] };
-            }
-          } else {
-            // TODO: this gets overwritten for subqueries with "&" operators
-            subqueries[property] = propertyValue;
-          }
-        });
-        // pass all search parameter-related _typeFilter queries into the Asymmetrik query builder
-        if (Object.keys(subqueries).length > 0) {
-          const filter = qb.buildSearchQuery({
-            req: { method: 'GET', query: subqueries, params: {} },
-            parameterDefinitions: searchParams,
-            includeArchived: true
-          });
-          if (filter.query) {
-            if (searchParameterQueries[resourceType]) {
-              searchParameterQueries[resourceType].push(filter.query);
-            } else {
-              searchParameterQueries[resourceType] = [filter.query];
-            }
-          }
-        }
-      });
+      addTypeFilter(typeFilter, searchParameterQueries, valueSetQueries);
     }
 
     const elementsQueries = {};
@@ -294,6 +248,7 @@ const exportToNDJson = async jobOptions => {
  * @returns {Object} An object containing all data from the given collection name as well as the collection name
  */
 const getDocuments = async (collectionName, searchParameterQueries, valueSetQueries, patientIds, elements) => {
+  console.log(`?????? GetDocuments ${JSON.stringify(searchParameterQueries)}`);
   let docs = [];
   let patQuery = {};
   let vsQuery = {};
@@ -335,6 +290,7 @@ const getDocuments = async (collectionName, searchParameterQueries, valueSetQuer
   }
 
   if (searchParameterQueries) {
+    console.log(`!!! searchParameterQueries !!! ${JSON.stringify(searchParameterQueries)}`);
     docs = searchParameterQueries.map(async q => {
       let query = q;
       // wherever we have a $match, we need to add another "and" operator containing the ValueSet and/or patient query
@@ -459,4 +415,60 @@ const patientsQueryForType = async function (patientIds, type) {
   return { $or: results };
 };
 
-module.exports = { exportToNDJson, patientsQueryForType, getDocuments, buildSearchParamList };
+/**
+ * Adds valueSet ans searchParameter queries based on a query's typeFilter value
+ * @param {string} typeFilter the type filter query from the request
+ * @param {Object} valueSetQueries mongo queries for valuesets
+ * @param {string} searchParameterQueries mongo queries for search parameters
+ */
+const addTypeFilter = function (typeFilter, valueSetQueries, searchParameterQueries) {
+  // subqueries may be joined together with a comma or as an array for a logical "or"
+  const tyq = Array.isArray(typeFilter) ? typeFilter : typeFilter.split(',');
+  // loop over each subquery and extract all search params, which are joined via the "&" operator
+  // each subquery is of the format <resource type>?<query>
+  tyq.forEach(query => {
+    const resourceType = query.substring(0, query.indexOf('?'));
+    // build mapping of search parameters for the given resource type
+    const searchParams = buildSearchParamList(resourceType);
+    // extract all properties that may be part of the same subquery via the "&" operator
+    const properties = query.substring(query.indexOf('?') + 1).split('&');
+    // create mapping of properties to their values within the given subquery
+    const subqueries = {};
+    properties.forEach(p => {
+      const property = p.substring(0, p.indexOf('='));
+      const propertyValue = p.substring(p.indexOf('=') + 1);
+      // type:in, code:in, etc.
+      if (property.endsWith(':in')) {
+        if (valueSetQueries[resourceType]) {
+          if (valueSetQueries[resourceType][property]) {
+            valueSetQueries[resourceType][property].push(propertyValue);
+          } else {
+            valueSetQueries[resourceType][property] = [propertyValue];
+          }
+        } else {
+          valueSetQueries[resourceType] = { [property]: [propertyValue] };
+        }
+      } else {
+        // TODO: this gets overwritten for subqueries with "&" operators
+        subqueries[property] = propertyValue;
+      }
+    });
+    // pass all search parameter-related _typeFilter queries into the Asymmetrik query builder
+    if (Object.keys(subqueries).length > 0) {
+      const filter = qb.buildSearchQuery({
+        req: { method: 'GET', query: subqueries, params: {} },
+        parameterDefinitions: searchParams,
+        includeArchived: true
+      });
+      if (filter.query) {
+        if (searchParameterQueries[resourceType]) {
+          searchParameterQueries[resourceType].push(filter.query);
+        } else {
+          searchParameterQueries[resourceType] = [filter.query];
+        }
+      }
+    }
+  });
+};
+
+module.exports = { exportToNDJson, patientsQueryForType, getDocuments, buildSearchParamList, addTypeFilter };

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -1,6 +1,6 @@
 const { createResource } = require('./mongo.controller');
 const { createOperationOutcome } = require('./errorUtils');
-const PATIENT_REFERENCES = require('../compartment-definition/patient-references');
+const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
 const _ = require('lodash');
 const { addTypeFilter, getDocuments } = require('./exportToNDJson');
 
@@ -117,7 +117,7 @@ async function actualizeGroup(group, reply) {
       const patientRefs = expResources.flatMap(expRes => {
         // example: expRes is AllergyIntolerance instance A
         // creates an array of defined values for [A.asserter,A.patient,A.recorder]
-        return PATIENT_REFERENCES[k].filter(path => expRes[path]).map(path => expRes[path].reference);
+        return patientAttributePaths[k].filter(path => expRes[path]).map(path => expRes[path].reference);
       });
 
       return _.uniq(patientRefs);

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -107,7 +107,7 @@ async function actualizeGroup(group, reply) {
   const patientSets = await Promise.all(
     Object.keys(resourceMap).map(async k => {
       //2,3
-      // list of resources of a single type (i.e encounters) that the patient could reference
+      // list of resources of a single type (i.e. encounters) that the patient could reference
       const expResources = await findExpressionResources(k, resourceMap[k]);
       //4,5
       const patientRefs = expResources.flatMap(expRes => {
@@ -126,7 +126,7 @@ async function actualizeGroup(group, reply) {
 
 /**
  * Applicable to a non-actual group to determine members
- * @param {string[]} expArr list of expressions that should be OR'd together to find resources (of the same type)
+ * @param {string[]} expArr list of expressions that should be ORd together to find resources (of the same type)
  * @returns {Object[]} array of resources that match one of the expressions
  */
 async function findExpressionResources(resourceType, expArr) {


### PR DESCRIPTION
# Summary
Functionality to export criteria-based groups, which are defined by the group member-filters


## New behavior
For a non-actual group that's been created, the server can now do a group export that will actualized the members of that group based on the member-filters as defined in https://build.fhir.org/ig/HL7/bulk-data/branches/argo24/group.html#bulk-cohort-api

Limitations: Our server does not have enough support for date searches that we can demonstrate this for a group directly built from a measure's IPP functionality. We already have ticket 1540 created to address our date limitations. For now, we need custom groups to best test this functionality.

## Code changes

- Adds lodash library for easier set management
- Updates in `export.service.js` to actualize the members of the group if the group is not `actual=true`
- Updates in exportToNDJson.js to move some typeFilter logic into a reusable `addTypeFilter` function
- `groupUtils.js` contains the main meat of the logic for this functionality. It has a couple of small changes to `verifyPatientsInGroup` to compensate for non-actual groups. Then `actualizeGroup` creates the group of Patients based on the member-filter expressions

# Testing guidance

Because of our date limitations, I've created a doctored group to test this functionality. I will share an Insomnia set in slack.

- `npm run check`
- `npm run db:reset`
- `npm run start`
- Run POSTs from the insomnia set
- Copy the group id to the Group export GET
- Check the resulting status
- Check the resulting Patient ndjson. This file should have the 3 test patients from the cervical cancer screening measure, but not the 4th patient that was uploaded in the second transaction bundle. This 4th patient is a copy of the denominator patient but with an altered code that should exclude it from the defined group.
- (optional) `npm run db:reset` and `npm run upload-bundles` if you want to return to a more populated database

