### PR TITLE
Collect data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ coverage
 docker_ssl_setup.sh
 tmp/123456/Account.ndjson
 ecqm-content-r4-2021
+ecqm-content-qicore-2025
 *.ndjson

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 coverage
 ecqm-content-r4-2021
+ecqm-content-qicore-2025

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -4,7 +4,7 @@ const mongoUtil = require('../util/mongo');
 const { createResource } = require('../util/mongo.controller');
 const { createPatientGroupsPerMeasure } = require('../util/groupUtils');
 
-const ecqmContentR4Path = path.resolve(path.join(__dirname, '../../ecqm-content-r4-2021/bundles/measure/'));
+const ecqmContentR4Path = path.resolve(path.join(__dirname, '../../ecqm-content-qicore-2025/bundles/measure/'));
 
 // files containing EXM bundles of interest from specified directory
 const bundleFiles = [];
@@ -57,7 +57,7 @@ const getBundleFiles = (directory, searchPattern) => {
  * Uploads all the resources from the specified directory into the
  * database.
  *
- * TODO: Currently configured for ecqm-content-r4-2021 measure bundles,
+ * TODO: Currently configured for ecqm-content-qicore-2025 measure bundles,
  * but may want to expand to other measure bundle providers in the future.
  */
 async function main() {
@@ -80,18 +80,18 @@ async function main() {
       throw new Error('Provided directory not found.');
     }
 
-    // otherwise load from ecqm-content-r4-2021
+    // otherwise load from ecqm-content-qicore-2025
   } else {
     try {
       if (!searchPattern) {
         // default searchPattern to retrieve all filenames that begin with a capital letter and end with -bundle.json
         searchPattern = /^[A-Z].*-bundle.json$/;
       }
-      console.log(`Finding bundles in ecqm-content-r4-2021 repo at ${ecqmContentR4Path}.`);
+      console.log(`Finding bundles in ecqm-content-qicore-2025 repo at ${ecqmContentR4Path}.`);
       getEcqmBundleFiles(ecqmContentR4Path, searchPattern);
     } catch {
       throw new Error(
-        'ecqm-content-r4-2021 directory not found. Git clone the ecqm-content-r4-2021 repo into the root directory and run script again'
+        'ecqm-content-qicore-2025 directory not found. Git clone the ecqm-content-qicore-2025 repo into the root directory and run script again'
       );
     }
   }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,7 +1,7 @@
 const fastify = require('fastify');
 const cors = require('@fastify/cors');
 
-const { bulkExport, patientBulkExport, groupBulkExport } = require('../services/export.service');
+const { bulkExport, patientBulkExport, groupBulkExport, collectData } = require('../services/export.service');
 const { checkBulkStatus, kickoffImport } = require('../services/bulkstatus.service');
 const { returnNDJsonContent } = require('../services/ndjson.service');
 const { groupSearchById, groupSearch, groupCreate, groupUpdate, groupRemove } = require('../services/group.service');
@@ -39,6 +39,10 @@ function build(opts) {
   app.post('/Patient', patientCreate);
   app.put('/Patient/:patientId', patientUpdate);
   app.delete('/Patient/:patientId', patientRemove);
+  app.get('/Measure/$collect-data', collectData);
+  app.post('/Measure/$collect-data', collectData);
+  app.get('/Measure/:measureId/$collect-data', collectData);
+  app.post('/Measure/:measureId/$collect-data', collectData);
 
   return app;
 }

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -450,11 +450,10 @@ const collectData = async (request, reply) => {
     const bundles = await Promise.all(
       patientIds.map(async id => {
         const patient = await findResourceById(id, 'Patient');
-        const measureReports = [];
-        const patientResourcePromises = measures.map(async measure => {
-          const patientResources = await findPatientResources(patient, measure);
-          measureReports.push(
-            createDataExchangeMeasureReport(
+        const resourcesMRPairs = await Promise.all(
+          measures.map(async measure => {
+            const patientResources = await findPatientResources(patient, measure);
+            const measureReport = createDataExchangeMeasureReport(
               measure,
               {
                 start: parameters.periodStart,
@@ -462,11 +461,11 @@ const collectData = async (request, reply) => {
               },
               id,
               patientResources
-            )
-          );
-          return patientResources;
-        });
-        const patientResourcesArray = await Promise.all(patientResourcePromises);
+            );
+            return [patientResources, measureReport];
+          })
+        );
+        const [patientResourcesArray, measureReports] = _.unzip(resourcesMRPairs);
         const uniqueResources = _.uniqBy(
           patientResourcesArray.flat(),
           resource => `${resource.resourceType}/${resource.id}`

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -6,6 +6,7 @@ const patientResourceTypes = Object.keys(patientAttributePaths);
 const { createOperationOutcome } = require('../util/errorUtils');
 const { verifyPatientsInGroup, actualizeGroup } = require('../util/groupUtils');
 const { gatherParams } = require('../util/serviceUtils');
+const _ = require('lodash');
 const {
   createDataExchangeMeasureReport,
   createPatientBundle,
@@ -459,33 +460,42 @@ const collectData = async (request, reply) => {
     // TODO: measureId (0..*) should be handled correctly when gathering parameters, add other 0..* are handled as arrays in gatherParams
     // i.e., could have additional {"name": "measureId","valueId": "measure1"} specified
 
-    const measureId = parameters.measureId[0];
-    const measure = await findResourceById(measureId, 'Measure');
-    if (!measure) {
-      throw Error(`Unable to find measure with measureId ${measureId}`);
-    }
     const patientIds = [parameters.subject.split('Patient/')[1]];
+    // Check for measure resolution - errors if there are any issues with measures passed
+    const measurePromises = parameters.measureId.map(async id => {
+      const measure = await findResourceById(id, 'Measure');
+      if (!measure) {
+        reply.code(404).send(new Error(`Unable to find measure with measureId ${id}`));
+      }
+      return measure;
+    });
+    const measures = await Promise.all(measurePromises);
 
     const bundles = await Promise.all(
       patientIds.map(async id => {
         const patient = await findResourceById(id, 'Patient');
-        const patientResources = await findPatientResources(patient, measure);
-        return createPatientBundle(
-          patient,
-          patientResources.map(r => {
-            return { resource: r };
-          }), //map from resources to BundleEntrys
-          patient.fullUrl ?? `urn:uuid:${id}`,
-          createDataExchangeMeasureReport(
-            measure,
-            {
-              start: parameters.periodStart,
-              end: parameters.periodEnd
-            },
-            id,
-            patientResources
-          )
+        const measureReports = [];
+        const patientResourcePromises = measures.map(async measure => {
+          const patientResources = await findPatientResources(patient, measure);
+          measureReports.push(
+            createDataExchangeMeasureReport(
+              measure,
+              {
+                start: parameters.periodStart,
+                end: parameters.periodEnd
+              },
+              id,
+              patientResources
+            )
+          );
+          return patientResources;
+        });
+        const patientResourcesArray = await Promise.all(patientResourcePromises);
+        const uniqueResources = _.uniqBy(
+          patientResourcesArray.flat(),
+          resource => `${resource.resourceType}/${resource.id}`
         );
+        return createPatientBundle(patient, uniqueResources, measureReports);
       })
     );
 

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -432,33 +432,9 @@ async function validatePatientReferences(patientParam, reply) {
 const collectData = async (request, reply) => {
   const parameters = gatherParams(request.method, request.query, request.body, reply);
 
-  // TODO: make sure measureId isn't specified differently in url and parameters
+  // TODO: validate measureId isn't specified differently in url and parameters
   if (validateCollectDataParams(parameters, reply)) {
     request.log.info('Measure >>> $collect-data');
-
-    // Easiest case (measureId and single patient subject) - TODO: handle other parameters, multiple patients/measures
-    //   Example:
-    //   {
-    //   "resourceType": "Parameters",
-    //   "parameter": [
-    //     {"name": "periodStart",
-    // 		 "valueDate": "2023-01-01"
-    // 		},
-    //     {"name": "periodEnd",
-    // 		 "valueDate": "2023-12-31"
-    // 		},
-    // 		{
-    //       "name": "measureId",
-    // 			"valueId": "measure1"
-    //     },
-    //     {
-    //       "name": "subject",
-    //       "valueString": "Patient/patient03"
-    //     }
-    //   ]
-    // }
-    // TODO: measureId (0..*) should be handled correctly when gathering parameters, add other 0..* are handled as arrays in gatherParams
-    // i.e., could have additional {"name": "measureId","valueId": "measure1"} specified
 
     const patientIds = [parameters.subject.split('Patient/')[1]];
     // Check for measure resolution - errors if there are any issues with measures passed
@@ -510,7 +486,7 @@ const collectData = async (request, reply) => {
  * @param {Object} reply the response object
  */
 function validateCollectDataParams(parameters, reply) {
-  // TODO: Update with additional validations (and not supporteds as applicable)
+  // TODO: Update with additional validations
 
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
@@ -529,7 +505,8 @@ function validateCollectDataParams(parameters, reply) {
         'lastReceivedOn',
         'organizationResource',
         'organization',
-        'validateResources'
+        'validateResources',
+        'dataEndpoint'
       ].includes(param)
     ) {
       unrecognizedParams.push(param);
@@ -542,6 +519,24 @@ function validateCollectDataParams(parameters, reply) {
         createOperationOutcome(
           `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
           { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+  // TODO: support other parameters that are currently unsupported
+  let unsupportedParams = [];
+  Object.keys(parameters).forEach(param => {
+    if (!['periodStart', 'periodEnd', 'measureId', 'subject'].includes(param)) {
+      unsupportedParams.push(param);
+    }
+  });
+  if (unsupportedParams.length > 0) {
+    reply
+      .code(501)
+      .send(
+        createOperationOutcome(
+          `The following parameters are not yet supported by the server: ${unsupportedParams.join(', ')}.`,
+          { issueCode: 501, severity: 'error' }
         )
       );
     return false;

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -469,9 +469,10 @@ const collectData = async (request, reply) => {
     const bundles = await Promise.all(
       patientIds.map(async id => {
         const patient = await findResourceById(id, 'Patient');
+        const patientResources = await findPatientResources(patient, measure);
         return createPatientBundle(
           patient,
-          (await findPatientResources(patient, measure)).map(r => {
+          patientResources.map(r => {
             return { resource: r };
           }), //map from resources to BundleEntrys
           patient.fullUrl ?? `urn:uuid:${id}`,
@@ -481,7 +482,8 @@ const collectData = async (request, reply) => {
               start: parameters.periodStart,
               end: parameters.periodEnd
             },
-            id
+            id,
+            patientResources
           )
         );
       })

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -6,7 +6,11 @@ const patientResourceTypes = Object.keys(patientAttributePaths);
 const { createOperationOutcome } = require('../util/errorUtils');
 const { verifyPatientsInGroup, actualizeGroup } = require('../util/groupUtils');
 const { gatherParams } = require('../util/serviceUtils');
-const { createDataExchangeMeasureReport, createPatientBundle } = require('../util/collectDataUtils');
+const {
+  createDataExchangeMeasureReport,
+  createPatientBundle,
+  findPatientResources
+} = require('../util/collectDataUtils');
 
 /**
  * Exports data from a FHIR server, whether or not it is associated with a patient.
@@ -426,61 +430,65 @@ async function validatePatientReferences(patientParam, reply) {
  */
 const collectData = async (request, reply) => {
   const parameters = gatherParams(request.method, request.query, request.body, reply);
+
   // TODO: make sure measureId isn't specified differently in url and parameters
   if (validateCollectDataParams(parameters, reply)) {
     request.log.info('Measure >>> $collect-data');
-    const bundleArr = [];
-    reply.code(200).send(bundleArr);
+
+    // Easiest case (measureId and single patient subject) - TODO: handle other parameters, multiple patients/measures
+    //   Example:
+    //   {
+    //   "resourceType": "Parameters",
+    //   "parameter": [
+    //     {"name": "periodStart",
+    // 		 "valueDate": "2023-01-01"
+    // 		},
+    //     {"name": "periodEnd",
+    // 		 "valueDate": "2023-12-31"
+    // 		},
+    // 		{
+    //       "name": "measureId",
+    // 			"valueId": "measure1"
+    //     },
+    //     {
+    //       "name": "subject",
+    //       "valueString": "Patient/patient03"
+    //     }
+    //   ]
+    // }
+    // TODO: measureId (0..*) should be handled correctly when gathering parameters, add other 0..* are handled as arrays in gatherParams
+    // i.e., could have additional {"name": "measureId","valueId": "measure1"} specified
+
+    const measureId = parameters.measureId[0];
+    const measure = await findResourceById(measureId, 'Measure');
+    if (!measure) {
+      throw Error(`Unable to find measure with measureId ${measureId}`);
+    }
+    const patientIds = [parameters.subject.split('Patient/')[1]];
+
+    const bundles = await Promise.all(
+      patientIds.map(async id => {
+        const patient = await findResourceById(id, 'Patient');
+        return createPatientBundle(
+          patient,
+          (await findPatientResources(patient, measure)).map(r => {
+            return { resource: r };
+          }), //map from resources to BundleEntrys
+          patient.fullUrl ?? `urn:uuid:${id}`,
+          createDataExchangeMeasureReport(
+            measure,
+            {
+              start: parameters.periodStart,
+              end: parameters.periodEnd
+            },
+            id
+          )
+        );
+      })
+    );
+
+    reply.code(200).send(bundles);
   }
-
-  // Easiest case (measureId and single patient subject) - TODO: handle other parameters, multiple patients/measures
-  //   Example:
-  //   {
-  //   "resourceType": "Parameters",
-  //   "parameter": [
-  //     {"name": "periodStart",
-  // 		 "valueDate": "2023-01-01"
-  // 		},
-  //     {"name": "periodEnd",
-  // 		 "valueDate": "2023-12-31"
-  // 		},
-  // 		{
-  //       "name": "measureId",
-  // 			"valueId": "measure1"
-  //     },
-  //     {
-  //       "name": "subject",
-  //       "valueString": "Patient/patient03"
-  //     }
-  //   ]
-  // }
-  // TODO: measureId (0..*) should be handled correctly when gathering parameters, add other 0..* are handled as arrays in gatherParams
-  // i.e., could have additional {"name": "measureId","valueId": "measure1"} specified
-
-  const measureId = parameters.measureId[0];
-  const measure = await findResourceById(measureId, 'Measure');
-  const patientIds = [parameters.subject.split('Patient/')[1]];
-
-  const bundles = await Promise.all(
-    patientIds.map(async id => {
-      const patient = await findResourceById(id, 'Patient');
-      return createPatientBundle(
-        patient,
-        [], //TODO: minimized patient resources ala minimizeTestCaseResources(currentPatients[id], measureBundle.content, drLookupByType),
-        patient.fullUrl ?? `urn:uuid:${id}`,
-        createDataExchangeMeasureReport(
-          measure,
-          {
-            start: parameters.periodStart,
-            end: parameters.periodEnd
-          },
-          id
-        )
-      );
-    })
-  );
-
-  reply.code(200).send(bundles);
 };
 
 /**

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -424,21 +424,21 @@ async function validatePatientReferences(patientParam, reply) {
 }
 
 /**
- * Implements $collect-data according to https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-collect-data.html
- * Returns a set of bundles that have data of interest for the specified measure, organized by the specified subject
+ * Implements limited parameters for $collect-data according to https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-collect-data.html
+ * Returns a set of bundles that have data of interest for the specified measures, organized by the specified subject
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
  */
 const collectData = async (request, reply) => {
   const parameters = gatherParams(request.method, request.query, request.body, reply);
 
-  // TODO: validate measureId isn't specified differently in url and parameters
   if (validateCollectDataParams(parameters, reply)) {
     request.log.info('Measure >>> $collect-data');
 
     const patientIds = [parameters.subject.split('Patient/')[1]];
     // Check for measure resolution - errors if there are any issues with measures passed
-    const measurePromises = parameters.measureId.map(async id => {
+    const measureArr = Array.isArray(parameters.measureId) ? parameters.measureId : [parameters.measureId];
+    const measurePromises = measureArr.map(async id => {
       const measure = await findResourceById(id, 'Measure');
       if (!measure) {
         reply.code(404).send(new Error(`Unable to find measure with measureId ${id}`));
@@ -486,8 +486,6 @@ const collectData = async (request, reply) => {
  * @param {Object} reply the response object
  */
 function validateCollectDataParams(parameters, reply) {
-  // TODO: Update with additional validations
-
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
     if (
@@ -523,7 +521,7 @@ function validateCollectDataParams(parameters, reply) {
       );
     return false;
   }
-  // TODO: support other parameters that are currently unsupported
+
   let unsupportedParams = [];
   Object.keys(parameters).forEach(param => {
     if (!['periodStart', 'periodEnd', 'measureId', 'subject'].includes(param)) {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -6,6 +6,7 @@ const patientResourceTypes = Object.keys(patientAttributePaths);
 const { createOperationOutcome } = require('../util/errorUtils');
 const { verifyPatientsInGroup, actualizeGroup } = require('../util/groupUtils');
 const { gatherParams } = require('../util/serviceUtils');
+const { createDataExchangeMeasureReport, createPatientBundle } = require('../util/collectDataUtils');
 
 /**
  * Exports data from a FHIR server, whether or not it is associated with a patient.
@@ -417,4 +418,115 @@ async function validatePatientReferences(patientParam, reply) {
   return false;
 }
 
-module.exports = { bulkExport, patientBulkExport, groupBulkExport };
+/**
+ * Implements $collect-data according to https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-collect-data.html
+ * Returns a set of bundles that have data of interest for the specified measure, organized by the specified subject
+ * @param {Object} request the request object passed in by the user
+ * @param {Object} reply the response object
+ */
+const collectData = async (request, reply) => {
+  const parameters = gatherParams(request.method, request.query, request.body, reply);
+  // TODO: make sure measureId isn't specified differently in url and parameters
+  if (validateCollectDataParams(parameters, reply)) {
+    request.log.info('Measure >>> $collect-data');
+    const bundleArr = [];
+    reply.code(200).send(bundleArr);
+  }
+
+  // Easiest case (measureId and single patient subject) - TODO: handle other parameters, multiple patients/measures
+  //   Example:
+  //   {
+  //   "resourceType": "Parameters",
+  //   "parameter": [
+  //     {"name": "periodStart",
+  // 		 "valueDate": "2023-01-01"
+  // 		},
+  //     {"name": "periodEnd",
+  // 		 "valueDate": "2023-12-31"
+  // 		},
+  // 		{
+  //       "name": "measureId",
+  // 			"valueId": "measure1"
+  //     },
+  //     {
+  //       "name": "subject",
+  //       "valueString": "Patient/patient03"
+  //     }
+  //   ]
+  // }
+  // TODO: measureId (0..*) should be handled correctly when gathering parameters, add other 0..* are handled as arrays in gatherParams
+  // i.e., could have additional {"name": "measureId","valueId": "measure1"} specified
+
+  const measureId = parameters.measureId[0];
+  const measure = await findResourceById(measureId, 'Measure');
+  const patientIds = [parameters.subject.split('Patient/')[1]];
+
+  const bundles = await Promise.all(
+    patientIds.map(async id => {
+      const patient = await findResourceById(id, 'Patient');
+      return createPatientBundle(
+        patient,
+        [], //TODO: minimized patient resources ala minimizeTestCaseResources(currentPatients[id], measureBundle.content, drLookupByType),
+        patient.fullUrl ?? `urn:uuid:${id}`,
+        createDataExchangeMeasureReport(
+          measure,
+          {
+            start: parameters.periodStart,
+            end: parameters.periodEnd
+          },
+          id
+        )
+      );
+    })
+  );
+
+  reply.code(200).send(bundles);
+};
+
+/**
+ * Checks that the parameters input to $collect-data are valid. Returns true if all the
+ * export params are valid, meaning no errors were thrown in the process.
+ * @param {Object} parameters object containing a combination of request parameters from request query and body
+ * @param {Object} reply the response object
+ */
+function validateCollectDataParams(parameters, reply) {
+  // TODO: Update with additional validations (and not supporteds as applicable)
+
+  let unrecognizedParams = [];
+  Object.keys(parameters).forEach(param => {
+    if (
+      ![
+        'periodStart',
+        'periodEnd',
+        'measureId',
+        'measureIdentifier',
+        'measureUrl',
+        'measureResource',
+        'measure',
+        'subject',
+        'subjectGroup',
+        'practitioner',
+        'lastReceivedOn',
+        'organizationResource',
+        'organization',
+        'validateResources'
+      ].includes(param)
+    ) {
+      unrecognizedParams.push(param);
+    }
+  });
+  if (unrecognizedParams.length > 0) {
+    reply
+      .code(400)
+      .send(
+        createOperationOutcome(
+          `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
+          { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+  return true;
+}
+
+module.exports = { bulkExport, patientBulkExport, groupBulkExport, collectData };

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -1,0 +1,92 @@
+const { v4: uuidv4 } = require('uuid');
+/**
+ * Creates a patient bundle resource. Creates using a patient resource and
+ * an array of the patient's associated resources
+ * @param {Object} patient FHIR Patient object
+ * @param {Array} entries array of FHIR BundleEntry's associated with the patient
+ * @param {String} fullUrl fullUrl for patient
+ * @param {Object} testMeasureReport MeasureReport specifying measure information for data exchagne
+ * @returns {Object} a FHIR patient bundle resource
+ */
+export function createPatientBundle(patient, entries, fullUrl, measureReport) {
+  const bundle = {
+    type: 'transaction',
+    resourceType: 'Bundle',
+    id: uuidv4(),
+    entry: [
+      {
+        resource: patient,
+        request: {
+          method: 'PUT',
+          url: `Patient/${patient.id}`
+        },
+        fullUrl: fullUrl
+      }
+    ]
+  };
+  entries.forEach(entry => {
+    bundle.entry?.push({
+      ...entry,
+      request: {
+        method: 'PUT',
+        url: `${entry.resource?.resourceType}/${entry.resource?.id}`
+      }
+    });
+  });
+
+  bundle.entry?.push({
+    resource: measureReport,
+    request: {
+      method: 'PUT',
+      url: `MeasureReport/${measureReport.id}`
+    },
+    fullUrl: `urn:uuid:${measureReport.id}`
+  });
+
+  return bundle;
+}
+
+/**
+ * Creates a FHIR data exchange MeasureReport from measure and subject data
+ * https://build.fhir.org/ig/HL7/davinci-deqm/StructureDefinition-datax-measurereport-deqm.html
+ * @param measure FHIR Measure
+ * @param measurementPeriod FHIR Period representing the measurement period
+ * @param subjectId the patient id the MeasureReport is associated with
+ * @returns { fhir4.MeasureReport } a data exchange measure report used to send Measure-relevant data to a server
+ */
+export function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId) {
+  return {
+    resourceType: 'MeasureReport',
+    id: uuidv4(),
+    measure: measure.url?.includes('|') ? measure.url : `${measure.url}|${measure.version}`, //canonical measure/version
+    period: measurementPeriod,
+    status: 'complete',
+    type: 'data-collection',
+    subject: { reference: `Patient/${subjectId}` },
+    date: jsDateToFHIRDate(new Date()),
+    reporter: { reference: 'Organization/bulk-export-server' }, //TODO: do we need to send an organization resource?
+    meta: {
+      profile: ['http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/datax-measurereport-deqm']
+    },
+    extension: [
+      {
+        url: 'http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType',
+        valueCode: 'snapshot'
+      }
+    ],
+    contained: [{ resourceType: 'Organization', id: 'bulk-export-server' }]
+  };
+}
+
+/**
+ * Converts a JS date to a FHIR date string
+ * @param {Date} date JS date to be converted
+ * @returns {String} a string representing a FHIR date
+ */
+export function jsDateToFHIRDate(date) {
+  const year = date.getFullYear();
+  // month is 0 indexed
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`;
+}

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -101,7 +101,7 @@ function jsDateToFHIRDate(date) {
  */
 async function findPatientResources(patient, measure) {
   const dataRequirements = measure.contained.find(c => c.id === 'effective-data-requirements').dataRequirement;
-  const types = _.uniq(dataRequirements.map(dr => dr.type)); //patientResourceTypes; //TODO: make sure that resulting types are in patientResourceTypes if we think that's useful? throw error
+  const types = _.uniq(dataRequirements.map(dr => dr.type));
   const [patientTypes, nonPatientTypes] = types.reduce(
     ([patient, nonPatient], type) => {
       (patientResourceTypes.includes(type) ? patient : nonPatient).push(type);
@@ -109,6 +109,8 @@ async function findPatientResources(patient, measure) {
     },
     [[], []]
   );
+  // TODO: Handle non-patient types more elegantly/completely
+  // i.e. Patient references MedicationRequest references Medication could end up with Medication as non-patient type
   console.warn('Ignoring non-patient types found in data requirements:', nonPatientTypes);
   const typeFilters = typeFiltersForMeasure(dataRequirements);
   // create lookup objects for (1) _typeFilter queries that contain search parameters, and (2) _typeFilter
@@ -180,159 +182,5 @@ function typeFiltersForMeasure(dataRequirements) {
   // array of typeFilters that should be treated as OR'd (empty array will be ignored and flattened)
   return Object.values(typeFilters).flat();
 }
-
-// version with code=value only typeFilters
-// export function typeFiltersForMeasure(dataRequirements){
-//   // create record resourcetype => [] of valid typeFilter query strings that will be separated by "&" and logically handled as ORs
-//   const typeFilters = {};
-//   dataRequirements.results.dataRequirement?.forEach(dr => {
-//     //empty array is general _type query that overrides a more specific _typeFilter
-//     if (typeFilters[dr.type]?.length === 0) return;
-
-//     //any codeFilter that's non-coded or no-path or any contained codings have no code -> results in a general _type query
-//     if (dr.codeFilter?.some(cf => !cf.code || !cf.path || cf.code.some(coding => !coding.code))) {
-//       typeFilters[dr.type] = [];
-//       return;
-//     }
-//     //all codefilters have a path and proper code and can be added to our typefilter array
-//     const fhirQueries = dr.codeFilter?.map(cf => `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`); // potential multiple codes are comma-separated to be ORed for this path
-//     const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
-//     if (typeFilters[dr.type]) {
-//       typeFilters[dr.type]?.push(tfStr);
-//     } else {
-//       typeFilters[dr.type] = [tfStr];
-//     }
-//   });
-
-//   // array of typeFilters that should be treated as OR'd (empty array will be ignored and flattened)
-//   return Object.values(typeFilters).flat();
-
-// // Examples
-//     // MedicationRequest?status=completed&date=gt2018-07-01T00:00:00Z
-//     // MedicationRequest?type:in=[ValueSet-canonical-URL]
-//     // Observation?code=http://loinc.org|1234-5 or Observation?code=1234-5
-
-// }
-
-/**
- * Helper function that takes in a Patient object and a Measure object and uses the
- * measure data requirements to identify all Patient data relevant to the measure
- * Note: Uses measure's effective data requirements library
- */
-
-// The below approach starts with all patient-related resources and filters down from there
-// bulkQueries from https://github.com/projecttacoma/fqm-bulk-utils/pull/2 creates queries that are fairly
-// generic (might not narrow enough) and may not be effective on the server?
-//
-
-// export function minimalResources(patient, measure){
-//   const newResources = testCase.resources.filter(r => {
-//     // throw out any resources that are not in any of the dataRequirements
-//     // iterate over every resource in each bundle
-//     if (r.resource && r.resource?.resourceType) {
-//       // see if it matches any data requirements in the lookup object
-//       const matchingDRType = drLookupByType[r.resource.resourceType];
-//       if (matchingDRType) {
-//         const codeInfo = parsedCodePaths[r.resource.resourceType];
-//         // if the matching resource type's lookup object has keepAll set to true, meaning
-//         // the codeFilter on the data requirement was undefined, keep any resources of that type
-//         if (matchingDRType.keepAll === true) {
-//           return true;
-//         } else if (codeInfo.primaryCodePath) {
-//           const primaryCodeInfo = codeInfo.paths[codeInfo.primaryCodePath];
-
-//           if (primaryCodeInfo.codeType === 'FHIR.CodeableConcept') {
-//             if (primaryCodeInfo.choiceType === true) {
-//               if (primaryCodeInfo.multipleCardinality === true) {
-//                 // not sure if this happens based on codePaths.ts
-//               } else {
-//                 // example: MedicationRequest, DeviceRequest
-//                 const primaryCodeValue = fhirpath.evaluate(
-//                   r.resource,
-//                   `${codeInfo.primaryCodePath}CodeableConcept`
-//                 )[0] as fhir4.CodeableConcept;
-//                 const matchingCode = checkCodesAndValueSets(primaryCodeValue, matchingDRType, measureBundle);
-//                 if (matchingCode) {
-//                   return true;
-//                 }
-//               }
-//             } else {
-//               if (primaryCodeInfo.multipleCardinality === true) {
-//                 // example: Activity Definition, Appointment, Encounter
-//                 const primaryCodeValue = fhirpath.evaluate(
-//                   r.resource,
-//                   codeInfo.primaryCodePath
-//                 ) as fhir4.CodeableConcept[];
-//                 if (primaryCodeValue) {
-//                   if (primaryCodeValue.some(pcv => checkCodesAndValueSets(pcv, matchingDRType, measureBundle))) {
-//                     return true;
-//                   }
-//                 }
-//               } else {
-//                 const primaryCodeValue = fhirpath.evaluate(
-//                   r.resource,
-//                   codeInfo.primaryCodePath
-//                 )[0] as fhir4.CodeableConcept;
-//                 const matchingCode = checkCodesAndValueSets(primaryCodeValue, matchingDRType, measureBundle);
-//                 if (matchingCode) {
-//                   return true;
-//                 }
-//               }
-//             }
-//           } else if (primaryCodeInfo.codeType === 'FHIR.Coding') {
-//             if (primaryCodeInfo.choiceType === true) {
-//               if (primaryCodeInfo.multipleCardinality === true) {
-//                 // not sure if this happens based on codePaths.ts
-//               } else {
-//                 // example: MessageDefinition
-//                 const primaryCodeValue = fhirpath.evaluate(
-//                   r.resource,
-//                   `${codeInfo.primaryCodePath}Coding`
-//                 ) as fhir4.Coding;
-//                 if (primaryCodeValue) {
-//                   if (
-//                     matchingDRType.directCodes.length > 0 &&
-//                     matchingDRType.directCodes.some(
-//                       dc => dc.code === primaryCodeValue.code && dc.system === primaryCodeValue.system
-//                     )
-//                   ) {
-//                     return true;
-//                   } else if (matchingDRType.valueSets.length > 0) {
-//                     const vsCodesAndSystems = getValueSetCodes(matchingDRType.valueSets, measureBundle);
-//                     if (
-//                       vsCodesAndSystems.some(
-//                         vscas => primaryCodeValue.code === vscas.code && primaryCodeValue.system === vscas.system
-//                       )
-//                     ) {
-//                       return true;
-//                     }
-//                   }
-//                 }
-//               }
-//             } else {
-//               // not sure if this happens based on codePaths.ts
-//             }
-//           } else if (primaryCodeInfo.codeType === 'FHIR.code') {
-//             if (primaryCodeInfo.choiceType === true) {
-//               if (primaryCodeInfo.multipleCardinality === true) {
-//                 // not sure if this happens based on codePaths.ts
-//               } else {
-//                 // not sure if this happens based on codePaths.ts
-//               }
-//             } else {
-//               if (primaryCodeInfo.multipleCardinality === true) {
-//                 // example: SearchParameter
-//               } else {
-//                 // example: OperationDefinition
-//               }
-//             }
-//           }
-//         }
-//       }
-//     }
-//     return false;
-//   });
-//   return newResources;
-// }
 
 module.exports = { createPatientBundle, createDataExchangeMeasureReport, findPatientResources };

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
  * an array of the patient's associated resources
  * @param {Object} patient FHIR Patient object
  * @param {Array} resources array of resources associated with the patient
- * @param {Array} measureReports array of MeasureReport specifying measure information for data exchange
+ * @param {Array} measureReports array of MeasureReport resources specifying measure information for data exchange
  * @returns {Object} a FHIR patient bundle resource
  */
 function createPatientBundle(patient, resources, measureReports) {
@@ -46,7 +46,7 @@ function createPatientBundle(patient, resources, measureReports) {
 
 /**
  * Creates a FHIR data exchange MeasureReport from measure and subject data
- * https://build.fhir.org/ig/HL7/davinci-deqm/StructureDefinition-datax-measurereport-deqm.html
+ * https://hl7.org/fhir/us/davinci-deqm/STU5/StructureDefinition-datax-measurereport-deqm.html
  * @param measure FHIR Measure
  * @param measurementPeriod FHIR Period representing the measurement period
  * @param subjectId the patient id the MeasureReport is associated with
@@ -82,8 +82,8 @@ function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId, 
 
 /**
  * Finds all resources related to the passed patient resource but limited by the data requirements on the passed measure
- * @param {Object} patient fhir patient resource
- * @param {Object} measure fhir measure resource
+ * @param {FHIR.Patient} patient fhir patient resource
+ * @param {FHIR.Measure} measure fhir measure resource
  * @returns {Array} an array of filtered fhir resources related to the passed patient
  */
 async function findPatientResources(patient, measure) {
@@ -149,20 +149,20 @@ function typeFiltersForMeasure(dataRequirements) {
       const hasCode = cf.path && cf.code && cf.code.every(coding => !!coding.code);
       if (hasVS && hasCode) {
         // default to valueset method for now, but this should probably be expanded to a full list of codes from the vs with additional
-        // codes appended (or separated into separate top-leve queries where other included codeFilters are repeated
-        // Example: 'Procedure?code=1&category=3,4','Procedure?code=1&category:in=vs)')
+        // codes appended (or separated into separate top-level queries where other included codeFilters are repeated
+        // Example: 'Procedure?code=1&category=3,4','Procedure?code=1&category:in=vs')
         return `${cf.path}:in=${cf.valueSet}`;
       } else if (hasVS) {
         return `${cf.path}:in=${cf.valueSet}`;
       } else {
         // hasCode
-        // potential multiple codes are comma-separated to be ORed for this path
+        // potential multiple codes are comma-separated to be OR'd for this path
         return `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`;
       }
     });
     const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
     if (typeFilters[dr.type]) {
-      typeFilters[dr.type]?.push(tfStr);
+      typeFilters[dr.type].push(tfStr);
     } else {
       typeFilters[dr.type] = [tfStr];
     }

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -1,4 +1,9 @@
 const { v4: uuidv4 } = require('uuid');
+const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
+const patientResourceTypes = Object.keys(patientAttributePaths);
+const { addTypeFilter, getDocuments } = require('./exportToNDJson');
+const _ = require('lodash');
+
 /**
  * Creates a patient bundle resource. Creates using a patient resource and
  * an array of the patient's associated resources
@@ -8,7 +13,7 @@ const { v4: uuidv4 } = require('uuid');
  * @param {Object} testMeasureReport MeasureReport specifying measure information for data exchagne
  * @returns {Object} a FHIR patient bundle resource
  */
-export function createPatientBundle(patient, entries, fullUrl, measureReport) {
+function createPatientBundle(patient, entries, fullUrl, measureReport) {
   const bundle = {
     type: 'transaction',
     resourceType: 'Bundle',
@@ -54,7 +59,7 @@ export function createPatientBundle(patient, entries, fullUrl, measureReport) {
  * @param subjectId the patient id the MeasureReport is associated with
  * @returns { fhir4.MeasureReport } a data exchange measure report used to send Measure-relevant data to a server
  */
-export function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId) {
+function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId) {
   return {
     resourceType: 'MeasureReport',
     id: uuidv4(),
@@ -83,10 +88,256 @@ export function createDataExchangeMeasureReport(measure, measurementPeriod, subj
  * @param {Date} date JS date to be converted
  * @returns {String} a string representing a FHIR date
  */
-export function jsDateToFHIRDate(date) {
+function jsDateToFHIRDate(date) {
+  // TODO: Just use .toISOString()???
   const year = date.getFullYear();
   // month is 0 indexed
   const month = date.getMonth() + 1;
   const day = date.getDate();
   return `${year}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`;
 }
+
+/**
+ * Finds all resources related to the passed patient resource but limited by the data requirements on the passed measure
+ * @param {Object} patient fhir patient resource
+ * @param {Object} measure fhir measure resource
+ * @returns {Array} an array of filtered fhir resources related to the passed patient
+ */
+async function findPatientResources(patient, measure) {
+  const dataRequirements = measure.contained.find(c => c.id === 'effective-data-requirements').dataRequirement;
+  const types = _.uniq(dataRequirements.map(dr => dr.type)); //patientResourceTypes; //TODO: make sure that resulting types are in patientResourceTypes if we think that's useful? throw error
+  const [patientTypes, nonPatientTypes] = types.reduce(
+    ([patient, nonPatient], type) => {
+      (patientResourceTypes.includes(type) ? patient : nonPatient).push(type);
+      return [patient, nonPatient];
+    },
+    [[], []]
+  );
+  console.warn('Ignoring non-patient types found in data requirements:', nonPatientTypes);
+  const typeFilters = typeFiltersForMeasure(dataRequirements);
+  // create lookup objects for (1) _typeFilter queries that contain search parameters, and (2) _typeFilter
+  // queries that contain type:in/code:in/etc. queries
+  const searchParameterQueries = {};
+  const valueSetQueries = {};
+  if (typeFilters) {
+    addTypeFilter(typeFilters, searchParameterQueries, valueSetQueries);
+  }
+
+  // for each patient, collect resource documents from each export type collection
+  const typeDocs = patientTypes.map(async collectionName => {
+    return (
+      await getDocuments(collectionName, searchParameterQueries[collectionName], valueSetQueries[collectionName], [
+        patient.id
+      ])
+    ).document;
+  });
+  const allDocs = await Promise.all(typeDocs);
+  console.log('allDocs', allDocs.flat());
+
+  //flatten all type arrays into a single array
+  return allDocs.flat();
+}
+
+function typeFiltersForMeasure(dataRequirements) {
+  // create record resourcetype => [] of valid typeFilter query strings that will be separated by "&" and logically handled as ORs
+  const typeFilters = {};
+  dataRequirements.forEach(dr => {
+    //empty array is general _type query that overrides a more specific _typeFilter
+    if (typeFilters[dr.type]?.length === 0) return;
+
+    if (
+      dr.codeFilter?.some(cf => {
+        const hasVS = cf.path && cf.valueSet;
+        const hasCode = cf.path && cf.code && cf.code.every(coding => !!coding.code);
+        const hasNeither = !hasVS && !hasCode;
+        return hasNeither;
+      })
+    ) {
+      // if any codeFilter for a data requirement doesn't have sufficient information, default to getting all for that type (general _type query)
+      typeFilters[dr.type] = [];
+      return;
+    }
+    //all codefilters have a path and proper code and can be added to our typefilter array
+    const fhirQueries = dr.codeFilter?.map(cf => {
+      const hasVS = cf.path && cf.valueSet;
+      const hasCode = cf.path && cf.code && cf.code.every(coding => !!coding.code);
+      if (hasVS && hasCode) {
+        // TODO: Is there a right way to do this case?
+        // filter returns items matching a code in the value set or one of the specified codes
+        // ORing these things together at this level doesn't seem to have a specified approach in https://hl7.org/fhir/R4/search.html#combining
+        // Try appending codes after vs url for lack of a better idea (i.e. type:in=[ValueSet-canonical-URL],1,2). This is almost definitely wrong
+        return `${cf.path}:in=${cf.valueSet},${cf.code?.map(coding => coding.code).join(',')}`;
+      } else if (hasVS) {
+        return `${cf.path}:in=${cf.valueSet}`;
+      } else {
+        // hasCode
+        return `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`;
+      }
+    }); // potential multiple codes are comma-separated to be ORed for this path
+    const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
+    if (typeFilters[dr.type]) {
+      typeFilters[dr.type]?.push(tfStr);
+    } else {
+      typeFilters[dr.type] = [tfStr];
+    }
+  });
+
+  // array of typeFilters that should be treated as OR'd (empty array will be ignored and flattened)
+  return Object.values(typeFilters).flat();
+}
+
+// version with code=value only typeFilters
+// export function typeFiltersForMeasure(dataRequirements){
+//   // create record resourcetype => [] of valid typeFilter query strings that will be separated by "&" and logically handled as ORs
+//   const typeFilters = {};
+//   dataRequirements.results.dataRequirement?.forEach(dr => {
+//     //empty array is general _type query that overrides a more specific _typeFilter
+//     if (typeFilters[dr.type]?.length === 0) return;
+
+//     //any codeFilter that's non-coded or no-path or any contained codings have no code -> results in a general _type query
+//     if (dr.codeFilter?.some(cf => !cf.code || !cf.path || cf.code.some(coding => !coding.code))) {
+//       typeFilters[dr.type] = [];
+//       return;
+//     }
+//     //all codefilters have a path and proper code and can be added to our typefilter array
+//     const fhirQueries = dr.codeFilter?.map(cf => `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`); // potential multiple codes are comma-separated to be ORed for this path
+//     const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
+//     if (typeFilters[dr.type]) {
+//       typeFilters[dr.type]?.push(tfStr);
+//     } else {
+//       typeFilters[dr.type] = [tfStr];
+//     }
+//   });
+
+//   // array of typeFilters that should be treated as OR'd (empty array will be ignored and flattened)
+//   return Object.values(typeFilters).flat();
+
+// // Examples
+//     // MedicationRequest?status=completed&date=gt2018-07-01T00:00:00Z
+//     // MedicationRequest?type:in=[ValueSet-canonical-URL]
+//     // Observation?code=http://loinc.org|1234-5 or Observation?code=1234-5
+
+// }
+
+/**
+ * Helper function that takes in a Patient object and a Measure object and uses the
+ * measure data requirements to identify all Patient data relevant to the measure
+ * Note: Uses measure's effective data requirements library
+ */
+
+// The below approach starts with all patient-related resources and filters down from there
+// bulkQueries from https://github.com/projecttacoma/fqm-bulk-utils/pull/2 creates queries that are fairly
+// generic (might not narrow enough) and may not be effective on the server?
+//
+
+// export function minimalResources(patient, measure){
+//   const newResources = testCase.resources.filter(r => {
+//     // throw out any resources that are not in any of the dataRequirements
+//     // iterate over every resource in each bundle
+//     if (r.resource && r.resource?.resourceType) {
+//       // see if it matches any data requirements in the lookup object
+//       const matchingDRType = drLookupByType[r.resource.resourceType];
+//       if (matchingDRType) {
+//         const codeInfo = parsedCodePaths[r.resource.resourceType];
+//         // if the matching resource type's lookup object has keepAll set to true, meaning
+//         // the codeFilter on the data requirement was undefined, keep any resources of that type
+//         if (matchingDRType.keepAll === true) {
+//           return true;
+//         } else if (codeInfo.primaryCodePath) {
+//           const primaryCodeInfo = codeInfo.paths[codeInfo.primaryCodePath];
+
+//           if (primaryCodeInfo.codeType === 'FHIR.CodeableConcept') {
+//             if (primaryCodeInfo.choiceType === true) {
+//               if (primaryCodeInfo.multipleCardinality === true) {
+//                 // not sure if this happens based on codePaths.ts
+//               } else {
+//                 // example: MedicationRequest, DeviceRequest
+//                 const primaryCodeValue = fhirpath.evaluate(
+//                   r.resource,
+//                   `${codeInfo.primaryCodePath}CodeableConcept`
+//                 )[0] as fhir4.CodeableConcept;
+//                 const matchingCode = checkCodesAndValueSets(primaryCodeValue, matchingDRType, measureBundle);
+//                 if (matchingCode) {
+//                   return true;
+//                 }
+//               }
+//             } else {
+//               if (primaryCodeInfo.multipleCardinality === true) {
+//                 // example: Activity Definition, Appointment, Encounter
+//                 const primaryCodeValue = fhirpath.evaluate(
+//                   r.resource,
+//                   codeInfo.primaryCodePath
+//                 ) as fhir4.CodeableConcept[];
+//                 if (primaryCodeValue) {
+//                   if (primaryCodeValue.some(pcv => checkCodesAndValueSets(pcv, matchingDRType, measureBundle))) {
+//                     return true;
+//                   }
+//                 }
+//               } else {
+//                 const primaryCodeValue = fhirpath.evaluate(
+//                   r.resource,
+//                   codeInfo.primaryCodePath
+//                 )[0] as fhir4.CodeableConcept;
+//                 const matchingCode = checkCodesAndValueSets(primaryCodeValue, matchingDRType, measureBundle);
+//                 if (matchingCode) {
+//                   return true;
+//                 }
+//               }
+//             }
+//           } else if (primaryCodeInfo.codeType === 'FHIR.Coding') {
+//             if (primaryCodeInfo.choiceType === true) {
+//               if (primaryCodeInfo.multipleCardinality === true) {
+//                 // not sure if this happens based on codePaths.ts
+//               } else {
+//                 // example: MessageDefinition
+//                 const primaryCodeValue = fhirpath.evaluate(
+//                   r.resource,
+//                   `${codeInfo.primaryCodePath}Coding`
+//                 ) as fhir4.Coding;
+//                 if (primaryCodeValue) {
+//                   if (
+//                     matchingDRType.directCodes.length > 0 &&
+//                     matchingDRType.directCodes.some(
+//                       dc => dc.code === primaryCodeValue.code && dc.system === primaryCodeValue.system
+//                     )
+//                   ) {
+//                     return true;
+//                   } else if (matchingDRType.valueSets.length > 0) {
+//                     const vsCodesAndSystems = getValueSetCodes(matchingDRType.valueSets, measureBundle);
+//                     if (
+//                       vsCodesAndSystems.some(
+//                         vscas => primaryCodeValue.code === vscas.code && primaryCodeValue.system === vscas.system
+//                       )
+//                     ) {
+//                       return true;
+//                     }
+//                   }
+//                 }
+//               }
+//             } else {
+//               // not sure if this happens based on codePaths.ts
+//             }
+//           } else if (primaryCodeInfo.codeType === 'FHIR.code') {
+//             if (primaryCodeInfo.choiceType === true) {
+//               if (primaryCodeInfo.multipleCardinality === true) {
+//                 // not sure if this happens based on codePaths.ts
+//               } else {
+//                 // not sure if this happens based on codePaths.ts
+//               }
+//             } else {
+//               if (primaryCodeInfo.multipleCardinality === true) {
+//                 // example: SearchParameter
+//               } else {
+//                 // example: OperationDefinition
+//               }
+//             }
+//           }
+//         }
+//       }
+//     }
+//     return false;
+//   });
+//   return newResources;
+// }
+
+module.exports = { createPatientBundle, createDataExchangeMeasureReport, findPatientResources };

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -18,16 +18,7 @@ function createPatientBundle(patient, entries, fullUrl, measureReport) {
     type: 'transaction',
     resourceType: 'Bundle',
     id: uuidv4(),
-    entry: [
-      {
-        resource: patient,
-        request: {
-          method: 'PUT',
-          url: `Patient/${patient.id}`
-        },
-        fullUrl: fullUrl
-      }
-    ]
+    entry: []
   };
   entries.forEach(entry => {
     bundle.entry?.push({
@@ -59,7 +50,7 @@ function createPatientBundle(patient, entries, fullUrl, measureReport) {
  * @param subjectId the patient id the MeasureReport is associated with
  * @returns { fhir4.MeasureReport } a data exchange measure report used to send Measure-relevant data to a server
  */
-function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId) {
+function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId, patientResources) {
   return {
     resourceType: 'MeasureReport',
     id: uuidv4(),
@@ -79,6 +70,9 @@ function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId) 
         valueCode: 'snapshot'
       }
     ],
+    evaluatedResource: patientResources.map(r => {
+      return { reference: `${r.resourceType}/${r.id}` };
+    }),
     contained: [{ resourceType: 'Organization', id: 'bulk-export-server' }]
   };
 }
@@ -144,6 +138,7 @@ function typeFiltersForMeasure(dataRequirements) {
   dataRequirements.forEach(dr => {
     //empty array is general _type query that overrides a more specific _typeFilter
     if (typeFilters[dr.type]?.length === 0) return;
+    // TODO: add profile conformance checking as specified in the data requirement
 
     if (
       dr.codeFilter?.some(cf => {

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -50,6 +50,7 @@ function createPatientBundle(patient, resources, measureReports) {
  * @param measure FHIR Measure
  * @param measurementPeriod FHIR Period representing the measurement period
  * @param subjectId the patient id the MeasureReport is associated with
+ * @param patientResources the patient resources of relevance to the passed measure
  * @returns { fhir4.MeasureReport } a data exchange measure report used to send Measure-relevant data to a server
  */
 function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId, patientResources) {
@@ -61,7 +62,7 @@ function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId, 
     status: 'complete',
     type: 'data-collection',
     subject: { reference: `Patient/${subjectId}` },
-    date: jsDateToFHIRDate(new Date()),
+    date: new Date().toISOString(),
     reporter: { reference: 'Organization/bulk-export-server' }, //TODO: do we need to send an organization resource?
     meta: {
       profile: ['http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/datax-measurereport-deqm']
@@ -72,25 +73,11 @@ function createDataExchangeMeasureReport(measure, measurementPeriod, subjectId, 
         valueCode: 'snapshot'
       }
     ],
-    evaluatedResource: patientResources.map(r => {
+    evaluatedResource: patientResources?.map(r => {
       return { reference: `${r.resourceType}/${r.id}` };
     }),
     contained: [{ resourceType: 'Organization', id: 'bulk-export-server' }]
   };
-}
-
-/**
- * Converts a JS date to a FHIR date string
- * @param {Date} date JS date to be converted
- * @returns {String} a string representing a FHIR date
- */
-function jsDateToFHIRDate(date) {
-  // TODO: Just use .toISOString()???
-  const year = date.getFullYear();
-  // month is 0 indexed
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  return `${year}-${month < 10 ? `0${month}` : month}-${day < 10 ? `0${day}` : day}`;
 }
 
 /**
@@ -100,7 +87,7 @@ function jsDateToFHIRDate(date) {
  * @returns {Array} an array of filtered fhir resources related to the passed patient
  */
 async function findPatientResources(patient, measure) {
-  const dataRequirements = measure.contained.find(c => c.id === 'effective-data-requirements').dataRequirement;
+  const dataRequirements = measure.contained?.find(c => c.id === 'effective-data-requirements').dataRequirement;
   const types = _.uniq(dataRequirements.map(dr => dr.type));
   const [patientTypes, nonPatientTypes] = types.reduce(
     ([patient, nonPatient], type) => {
@@ -109,9 +96,12 @@ async function findPatientResources(patient, measure) {
     },
     [[], []]
   );
-  // TODO: Handle non-patient types more elegantly/completely
+  // nonPatientTypes can be in data requirements when they may be referenced from other resources that reference patients
   // i.e. Patient references MedicationRequest references Medication could end up with Medication as non-patient type
-  console.warn('Ignoring non-patient types found in data requirements:', nonPatientTypes);
+  // ignored for now, but should either get all (non-patient query) or be able to do more complex query creation
+  if (nonPatientTypes.length > 0) {
+    console.warn('Ignoring non-patient types found in data requirements:', nonPatientTypes);
+  }
   const typeFilters = typeFiltersForMeasure(dataRequirements);
   // create lookup objects for (1) _typeFilter queries that contain search parameters, and (2) _typeFilter
   // queries that contain type:in/code:in/etc. queries
@@ -139,8 +129,7 @@ function typeFiltersForMeasure(dataRequirements) {
   const typeFilters = {};
   dataRequirements.forEach(dr => {
     //empty array is general _type query that overrides a more specific _typeFilter
-    if (typeFilters[dr.type]?.length === 0) return;
-    // TODO: add profile conformance checking as specified in the data requirement
+    if (typeFilters[dr.type]?.length === 0) return; // only handle data requirements with types for now
 
     if (
       dr.codeFilter?.some(cf => {
@@ -159,18 +148,18 @@ function typeFiltersForMeasure(dataRequirements) {
       const hasVS = cf.path && cf.valueSet;
       const hasCode = cf.path && cf.code && cf.code.every(coding => !!coding.code);
       if (hasVS && hasCode) {
-        // TODO: Is there a right way to do this case?
-        // filter returns items matching a code in the value set or one of the specified codes
-        // ORing these things together at this level doesn't seem to have a specified approach in https://hl7.org/fhir/R4/search.html#combining
-        // Try appending codes after vs url for lack of a better idea (i.e. type:in=[ValueSet-canonical-URL],1,2). This is almost definitely wrong
-        return `${cf.path}:in=${cf.valueSet},${cf.code?.map(coding => coding.code).join(',')}`;
+        // default to valueset method for now, but this should probably be expanded to a full list of codes from the vs with additional
+        // codes appended (or separated into separate top-leve queries where other included codeFilters are repeated
+        // Example: 'Procedure?code=1&category=3,4','Procedure?code=1&category:in=vs)')
+        return `${cf.path}:in=${cf.valueSet}`;
       } else if (hasVS) {
         return `${cf.path}:in=${cf.valueSet}`;
       } else {
         // hasCode
+        // potential multiple codes are comma-separated to be ORed for this path
         return `${cf.path}=${cf.code?.map(coding => coding.code).join(',')}`;
       }
-    }); // potential multiple codes are comma-separated to be ORed for this path
+    });
     const tfStr = `${dr.type}?${fhirQueries?.join('&')}`; //Example value: 'Procedure?code=1,2&category=3,4'
     if (typeFilters[dr.type]) {
       typeFilters[dr.type]?.push(tfStr);

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -8,35 +8,37 @@ const _ = require('lodash');
  * Creates a patient bundle resource. Creates using a patient resource and
  * an array of the patient's associated resources
  * @param {Object} patient FHIR Patient object
- * @param {Array} entries array of FHIR BundleEntry's associated with the patient
- * @param {String} fullUrl fullUrl for patient
- * @param {Object} testMeasureReport MeasureReport specifying measure information for data exchagne
+ * @param {Array} resources array of resources associated with the patient
+ * @param {Array} measureReports array of MeasureReport specifying measure information for data exchange
  * @returns {Object} a FHIR patient bundle resource
  */
-function createPatientBundle(patient, entries, fullUrl, measureReport) {
+function createPatientBundle(patient, resources, measureReports) {
   const bundle = {
     type: 'transaction',
     resourceType: 'Bundle',
     id: uuidv4(),
     entry: []
   };
-  entries.forEach(entry => {
+  resources.forEach(r => {
     bundle.entry?.push({
-      ...entry,
+      resource: r,
       request: {
         method: 'PUT',
-        url: `${entry.resource?.resourceType}/${entry.resource?.id}`
-      }
+        url: `${r.resourceType}/${r.id}`
+      },
+      fullUrl: r.fullUrl ?? `urn:uuid:${r.id}`
     });
   });
 
-  bundle.entry?.push({
-    resource: measureReport,
-    request: {
-      method: 'PUT',
-      url: `MeasureReport/${measureReport.id}`
-    },
-    fullUrl: `urn:uuid:${measureReport.id}`
+  measureReports.forEach(measureReport => {
+    bundle.entry?.push({
+      resource: measureReport,
+      request: {
+        method: 'PUT',
+        url: `MeasureReport/${measureReport.id}`
+      },
+      fullUrl: measureReport.fullUrl ?? `urn:uuid:${measureReport.id}`
+    });
   });
 
   return bundle;
@@ -125,11 +127,9 @@ async function findPatientResources(patient, measure) {
       ])
     ).document;
   });
-  const allDocs = await Promise.all(typeDocs);
-  console.log('allDocs', allDocs.flat());
 
   //flatten all type arrays into a single array
-  return allDocs.flat();
+  return (await Promise.all(typeDocs)).flat();
 }
 
 function typeFiltersForMeasure(dataRequirements) {

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -428,7 +428,7 @@ const processVSTypeFilter = async function (valueSetQueries) {
         let vs = await findOneResourceWithQuery({ url: value }, 'ValueSet');
         // throw an error if we don't have the value set
         if (!vs) {
-          throw new Error('Value set was not found in the database');
+          throw new Error(`Value set with value ${value} was not found in the database`);
         }
         const vsResolved = getCodesFromValueSet(vs);
         // extract the property (i.e. code, type)

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -440,7 +440,9 @@ const processVSTypeFilter = async function (valueSetQueries) {
       await Promise.all(results);
     }
   }
-
+  if (queryArray.length === 0) {
+    return {};
+  }
   return {
     $or: queryArray
   };

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -31,11 +31,17 @@ function gatherParams(method, query, body, reply) {
   if (body && body.parameter) {
     body.parameter.reduce((acc, e) => {
       if (!e.resource) {
-        if (e.name === 'patient' || e.name === 'measureId') {
+        if (e.name === 'patient') {
           if (!acc[e.name]) {
             acc[e.name] = [e.valueReference];
           } else {
             acc[e.name].push(e.valueReference);
+          }
+        } else if (e.name === 'measureId') {
+          if (!acc[e.name]) {
+            acc[e.name] = [e.valueId];
+          } else {
+            acc[e.name].push(e.valueId);
           }
         } else {
           // For now, all usable params are expected to be stored under one of these fives keys

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -31,7 +31,7 @@ function gatherParams(method, query, body, reply) {
   if (body && body.parameter) {
     body.parameter.reduce((acc, e) => {
       if (!e.resource) {
-        if (e.name === 'patient') {
+        if (e.name === 'patient' || e.name === 'measureId') {
           if (!acc[e.name]) {
             acc[e.name] = [e.valueReference];
           } else {

--- a/test/fixtures/testCondition.json
+++ b/test/fixtures/testCondition.json
@@ -5,5 +5,13 @@
   "recordedDate": "2019-01-03T00:00:00Z",
   "subject": {
     "reference": "Patient/testPatient"
-  }
+  },
+  "code":{
+      "coding": [
+        {
+          "system": "http://example.com",
+          "code": "example-code-2"
+        }
+      ]
+    }
 }

--- a/test/fixtures/testEncounter.json
+++ b/test/fixtures/testEncounter.json
@@ -4,6 +4,7 @@
     "subject": {
       "reference": "Patient/testPatient"
     },
+    "status": "finished",
     "type": {
       "coding": [
         {

--- a/test/fixtures/testMeasure.json
+++ b/test/fixtures/testMeasure.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "Measure",
+  "id": "testMeasure",
+  "library": ["Library/testLibrary"],
+  "contained": [
+    {
+      "resourceType": "Library",
+      "id": "effective-data-requirements",
+      "dataRequirement": [
+        {
+          "type": "Encounter",
+          "profile": [
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"
+          ],
+          "codeFilter": [
+            {
+              "path": "status",
+              "code": [
+                {
+                  "code": "finished"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Condition",
+          "profile": [
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"
+          ],
+          "codeFilter": [
+            {
+              "path": "code",
+              "valueSet": "http://example.com/ValueSet/exampleVS"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/testMeasure2.json
+++ b/test/fixtures/testMeasure2.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Measure",
+  "id": "testMeasure2",
+  "library": ["Library/testLibrary"],
+  "contained": [
+    {
+      "resourceType": "Library",
+      "id": "effective-data-requirements",
+      "dataRequirement": [
+        {
+          "type": "Encounter",
+          "profile": [
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"
+          ],
+          "codeFilter": [
+            {
+              "path": "status",
+              "code": [
+                {
+                  "code": "finished"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/testValueSet.json
+++ b/test/fixtures/testValueSet.json
@@ -1,0 +1,15 @@
+{
+    "resourceType" : "ValueSet",
+    "id" : "exampleVS",
+    "url" : "http://example.com/ValueSet/exampleVS",
+    "status" : "active",
+    "expansion" : {
+        "timestamp" : "2025-06-20T16:57:32-04:00",
+        "contains" : [
+            {
+                "system": "http://example.com",
+                "code": "example-code-2"
+            }
+        ]
+    }
+}

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -1,4 +1,9 @@
-const { bulkStatusSetup, cleanUpDb, createTestResource } = require('../populateTestData');
+const {
+  bulkStatusSetup,
+  cleanUpDb,
+  createTestResource,
+  createTestResourceWithConnect
+} = require('../populateTestData');
 const { db } = require('../../src/util/mongo');
 const build = require('../../src/server/app');
 const app = build();
@@ -6,6 +11,10 @@ const supertest = require('supertest');
 const queue = require('../../src/resources/exportQueue');
 const testPatient = require('../fixtures/testPatient.json');
 const testEncounter = require('../fixtures/testEncounter.json');
+const testCondition = require('../fixtures/testCondition.json');
+const testMeasure = require('../fixtures/testMeasure.json');
+const testMeasure2 = require('../fixtures/testMeasure2.json');
+const testValueSet = require('../fixtures/testValueSet.json');
 const testGroup = require('../fixtures/testGroup.json');
 
 // Mock export to do nothing
@@ -751,6 +760,205 @@ describe('Check organizeOutputBy=Patient export logic', () => {
         expect(response.body.issue[0].code).toEqual(400);
         expect(response.body.issue[0].details.text).toEqual(
           'When _type is specified with organizeOutputBy Patient, the Patient type must be included in the _type parameter.'
+        );
+      });
+  });
+
+  afterEach(async () => {
+    await cleanUpDb();
+  });
+});
+
+describe('Check collect-data logic', () => {
+  beforeEach(async () => {
+    await createTestResourceWithConnect(testPatient, 'Patient');
+    await createTestResource(testEncounter, 'Encounter');
+    await createTestResource(testCondition, 'Condition');
+    await createTestResource(testMeasure, 'Measure');
+    await createTestResource(testMeasure2, 'Measure');
+    await createTestResource(testValueSet, 'ValueSet');
+    await app.ready();
+  });
+
+  test('check 200 returned for valid GET request - one measure, single code', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureId=testMeasure2&subject=Patient/testPatient'
+      )
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        ); // check correct types
+        expect(response.body[0].entry).toEqual(
+          expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
+        ); // check specific resources
+      });
+  });
+
+  test('check 200 returned for valid POST request - one measure, single code', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        ); // check correct types
+        expect(response.body[0].entry).toEqual(
+          expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
+        ); // check specific resources
+      });
+  });
+
+  test('check 200 returned for valid POST request - one measure, valueset and single code', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body[0].entry).toHaveLength(3); //expect 1 measure report, encounter, and condition
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Condition', 'Encounter', 'MeasureReport'])
+        ); // check correct types
+        expect(response.body[0].entry).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' }),
+            expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
+          ])
+        ); // check specific resources
+      });
+  });
+
+  test('check 200 returned for valid POST request - two measures', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure'
+          },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body[0].entry).toHaveLength(4); //expect 2 measure reports, encounter, and condition
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Condition', 'Encounter', 'MeasureReport', 'MeasureReport'])
+        ); // check correct types
+        expect(response.body[0].entry).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' }),
+            expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
+          ])
+        ); // check specific resources
+      });
+  });
+
+  test('check 400 returned for unrecognized parameter', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          },
+          {
+            name: 'unrecognizedParam',
+            valueString: 'invalid'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following parameters are unrecognized by the server: unrecognizedParam.'
+        );
+      });
+  });
+
+  test('check 501 returned for unsupported valid parameter', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          },
+          {
+            name: 'validateResources',
+            valueBoolean: 'true'
+          }
+        ]
+      })
+      .expect(501)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following parameters are not yet supported by the server: validateResources.'
         );
       });
   });


### PR DESCRIPTION
# Summary
Adds support for a basic $collect-data according to the [STU5 definition](https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-collect-data.html)

## New behavior
Supports $collect-data parameters periodStart, periodEnd, measureId, and subject. Does not support all STU5 parameters or alternative parameters/requirements in the [latestBuild](https://build.fhir.org/ig/HL7/davinci-deqm/en/OperationDefinition-collect-data.html)

## Code changes

- Update premadeBundle upload default
- Add routes to app.js
- Add main collectData endpoint handling and validation to export service
- Create collectDataUtils for utilities: patient bundle and measure report creation, finding patient resources, creating typeFilters based on effective data requirements
- Small update to exportToNDJson.js to increase robustness
- Small updates to serviceUtils to handle gathering parameter input
- Testing: Add and update fixtures and unit testing of $collect-data operation in export.service.test.js


# Testing guidance

- `npm run check`
- Add ecqm-content-qicore-2025 bundles to your bulk-export-server directory (will be used instead of 2021 bundles)
- `npm run upload-bundles` (should load new default 2025 bundles)
- `npm run start`
- Run POST (or GET w/ URL parameters) to http://localhost:3000/Measure/$collect-data with
```
{
  "resourceType": "Parameters",
  "parameter": [
    {"name": "periodStart",
		 "valueDate": "2025-01-01"
		},
    {"name": "periodEnd",
		 "valueDate": "2025-12-31"
		},
		{
      "name": "measureId",
			"valueId": "CMS125FHIRBreastCancerScreening"
    },
		{
      "name": "measureId",
			"valueId": "CMS133FHIRCataracts2040BCVAwithin90Days"
    },
    {
      "name": "subject",
      "valueString": "Patient/62ea0c3d-46da-48a1-87dd-d1927ed2df75"
    }
  ]
}
```
- Experiment with other inputs, but see CollectDataBrainstorming document for caveats and potential follow-up actions (bottom of document) that would make this implementation more complete
