### PR TITLE
$collect-data measureUrl

### DIFF
--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -72,7 +72,7 @@ async function main() {
     const bundlePath = path.resolve(process.argv[2]);
     try {
       if (!searchPattern) {
-        searchPattern = /-bundle.json$/;
+        searchPattern = /.json$/;
       }
       console.log(`Finding bundles in ${bundlePath}.`);
       getBundleFiles(bundlePath, searchPattern);

--- a/src/scripts/uploadPremadeBundles.js
+++ b/src/scripts/uploadPremadeBundles.js
@@ -72,7 +72,7 @@ async function main() {
     const bundlePath = path.resolve(process.argv[2]);
     try {
       if (!searchPattern) {
-        searchPattern = /.json$/;
+        searchPattern = /-bundle.json$/;
       }
       console.log(`Finding bundles in ${bundlePath}.`);
       getBundleFiles(bundlePath, searchPattern);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -17,6 +17,11 @@ const {
 // set bodyLimit to 50mb
 function build(opts) {
   const app = fastify({ ...opts, bodyLimit: 50 * 1024 * 1024 });
+  app.addContentTypeParser(
+    ['application/json+fhir', 'application/fhir+json'],
+    { parseAs: 'string' },
+    app.getDefaultJsonParser('ignore', 'ignore')
+  );
   app.register(cors, { exposedHeaders: ['content-location', 'expires', 'x-progress', 'retry-after'] });
   app.get('/metadata', generateCapabilityStatement);
   app.get('/$export', bulkExport);

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -1,4 +1,4 @@
-const { addPendingBulkExportRequest, findResourceById } = require('../util/mongo.controller');
+const { addPendingBulkExportRequest, findResourceById, findResourceByCanonical } = require('../util/mongo.controller');
 const supportedResources = require('../util/supportedResources').filter(r => r !== 'ValueSet'); //exclude ValueSet (may be stored but not exported)
 const exportQueue = require('../resources/exportQueue');
 const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
@@ -437,15 +437,31 @@ const collectData = async (request, reply) => {
 
     const patientIds = [parameters.subject.split('Patient/')[1]];
     // Check for measure resolution - errors if there are any issues with measures passed
-    const measureArr = Array.isArray(parameters.measureId) ? parameters.measureId : [parameters.measureId];
-    const measurePromises = measureArr.map(async id => {
-      const measure = await findResourceById(id, 'Measure');
-      if (!measure) {
-        reply.code(404).send(new Error(`Unable to find measure with measureId ${id}`));
+    const measureArr = Array.isArray(parameters.measureUrl) ? parameters.measureUrl : [parameters.measureUrl];
+    const measures = [];
+    for (let url of measureArr) {
+      const resources = await findResourceByCanonical(url, 'Measure');
+
+      if (resources.length > 1) {
+        reply
+          .code(400)
+          .send(
+            createOperationOutcome(`Multiple versions of ${url} were found.`, { issueCode: 400, severity: 'error' })
+          );
+        return;
+      } else if (resources.length === 1) {
+        measures.push(resources[0]);
+      } else {
+        // return if we cant find a measure
+        reply.code(404).send(
+          createOperationOutcome(`Measure with url ${url} not found.`, {
+            issueCode: 404,
+            severity: 'error'
+          })
+        );
+        return;
       }
-      return measure;
-    });
-    const measures = await Promise.all(measurePromises);
+    }
 
     const bundles = await Promise.all(
       patientIds.map(async id => {
@@ -491,11 +507,7 @@ function validateCollectDataParams(parameters, reply) {
       ![
         'periodStart',
         'periodEnd',
-        'measureId',
-        'measureIdentifier',
         'measureUrl',
-        'measureResource',
-        'measure',
         'subject',
         'subjectGroup',
         'practitioner',
@@ -523,7 +535,7 @@ function validateCollectDataParams(parameters, reply) {
 
   let unsupportedParams = [];
   Object.keys(parameters).forEach(param => {
-    if (!['periodStart', 'periodEnd', 'measureId', 'subject'].includes(param)) {
+    if (!['periodStart', 'periodEnd', 'measureUrl', 'subject'].includes(param)) {
       unsupportedParams.push(param);
     }
   });

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -550,6 +550,12 @@ function validateCollectDataParams(parameters, reply) {
       );
     return false;
   }
+  if (!parameters.measureUrl) {
+    reply
+      .code(400)
+      .send(createOperationOutcome('At least one measureUrl is required.', { issueCode: 400, severity: 'error' }));
+    return false;
+  }
   return true;
 }
 

--- a/src/util/mongo.controller.js
+++ b/src/util/mongo.controller.js
@@ -30,6 +30,23 @@ const findResourceById = async (id, resourceType) => {
 };
 
 /**
+ * searches the database for the desired resource by canonical url
+ * @param {*} url canonical of desired resource
+ * @param {*} resourceType type of desired resource, signifies collection resource is stored in
+ * @returns the data of the found document
+ */
+const findResourceByCanonical = async (canonical, resourceType) => {
+  // break apart version if it exists
+  const [url, version] = canonical.split('|');
+  console.log(`Looking for measure ${url} with version ${version}`);
+  const collection = db.collection(resourceType);
+
+  return version
+    ? await collection.find({ url, version }, { projection: { _id: 0 } }).toArray()
+    : await collection.find({ url }, { projection: { _id: 0 } }).toArray();
+};
+
+/**
  * searches the database for the one resource based on a mongo query and returns the data
  * @param {Object} query the mongo query to use
  * @param {string} resourceType type of desired resource, signifies collection resource is stored in
@@ -192,6 +209,7 @@ const pushBulkStatusWarning = async (clientId, warning) => {
 module.exports = {
   findResourcesWithQuery,
   findResourceById,
+  findResourceByCanonical,
   findOneResourceWithQuery,
   createResource,
   removeResource,

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -37,15 +37,16 @@ function gatherParams(method, query, body, reply) {
           } else {
             acc[e.name].push(e.valueReference);
           }
-        } else if (e.name === 'measureId') {
+        } else if (e.name === 'measureUrl') {
           if (!acc[e.name]) {
-            acc[e.name] = [e.valueId];
+            acc[e.name] = [e.valueCanonical];
           } else {
-            acc[e.name].push(e.valueId);
+            acc[e.name].push(e.valueCanonical);
           }
         } else {
-          // For now, all usable params are expected to be stored under one of these fives keys
-          acc[e.name] = e.valueDate || e.valueString || e.valueId || e.valueCode || e.valueReference;
+          // For now, all usable params are expected to be stored under one of these six keys
+          acc[e.name] =
+            e.valueDate || e.valueString || e.valueId || e.valueCanonical || e.valueCode || e.valueReference;
         }
       }
       return acc;

--- a/test/fixtures/testMeasure.json
+++ b/test/fixtures/testMeasure.json
@@ -1,7 +1,11 @@
 {
   "resourceType": "Measure",
   "id": "testMeasure",
-  "library": ["Library/testLibrary"],
+  "url": "http://example.com/Measure/testMeasure",
+  "version": "1.0.0",
+  "library": [
+    "Library/testLibrary"
+  ],
   "contained": [
     {
       "resourceType": "Library",

--- a/test/fixtures/testMeasure2.json
+++ b/test/fixtures/testMeasure2.json
@@ -1,7 +1,11 @@
 {
   "resourceType": "Measure",
   "id": "testMeasure2",
-  "library": ["Library/testLibrary"],
+  "url": "http://example.com/Measure/testMeasure2",
+  "version": "1.0.1",
+  "library": [
+    "Library/testLibrary"
+  ],
   "contained": [
     {
       "resourceType": "Library",

--- a/test/fixtures/testMeasureV2.json
+++ b/test/fixtures/testMeasureV2.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "Measure",
+  "id": "testMeasure",
+  "url": "http://example.com/Measure/testMeasure",
+  "version": "2.0.0",
+  "library": [
+    "Library/testLibrary"
+  ],
+  "contained": [
+    {
+      "resourceType": "Library",
+      "id": "effective-data-requirements",
+      "dataRequirement": [
+        {
+          "type": "Encounter",
+          "profile": [
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-clinical-result"
+          ],
+          "codeFilter": [
+            {
+              "path": "status",
+              "code": [
+                {
+                  "code": "finished"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Condition",
+          "profile": [
+            "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"
+          ],
+          "codeFilter": [
+            {
+              "path": "code",
+              "valueSet": "http://example.com/ValueSet/exampleVS"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -13,6 +13,7 @@ const testPatient = require('../fixtures/testPatient.json');
 const testEncounter = require('../fixtures/testEncounter.json');
 const testCondition = require('../fixtures/testCondition.json');
 const testMeasure = require('../fixtures/testMeasure.json');
+const testMeasureV2 = require('../fixtures/testMeasureV2.json');
 const testMeasure2 = require('../fixtures/testMeasure2.json');
 const testValueSet = require('../fixtures/testValueSet.json');
 const testGroup = require('../fixtures/testGroup.json');
@@ -775,6 +776,7 @@ describe('Check collect-data logic', () => {
     await createTestResource(testEncounter, 'Encounter');
     await createTestResource(testCondition, 'Condition');
     await createTestResource(testMeasure, 'Measure');
+    await createTestResource(testMeasureV2, 'Measure');
     await createTestResource(testMeasure2, 'Measure');
     await createTestResource(testValueSet, 'ValueSet');
     await app.ready();
@@ -783,7 +785,7 @@ describe('Check collect-data logic', () => {
   test('check 200 returned for valid GET request - one measure with url, single code', async () => {
     await supertest(app.server)
       .get(
-        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http://example.com/Measure/testMeasure2&subject=Patient/testPatient'
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Patient/testPatient'
       )
       .expect(200)
       .then(response => {
@@ -801,7 +803,7 @@ describe('Check collect-data logic', () => {
   test('check 200 returned for valid GET request - one measure with url and version, single code', async () => {
     await supertest(app.server)
       .get(
-        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http://example.com/Measure/testMeasure2|1.0.1&subject=Patient/testPatient'
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2%7C1.0.1&subject=Patient/testPatient'
       )
       .expect(200)
       .then(response => {
@@ -826,7 +828,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUri: 'http://example.com/Measure/testMeasure2|1.0.1'
+            valueCanonical: 'http://example.com/Measure/testMeasure2|1.0.1'
           },
           {
             name: 'subject',
@@ -857,11 +859,11 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUri: 'http://example.com/Measure/testMeasure'
+            valueCanonical: 'http://example.com/Measure/testMeasure|1.0.0'
           },
           {
             name: 'measureUrl',
-            valueUri: 'http://example.com/Measure/testMeasure2|1.0.1'
+            valueCanonical: 'http://example.com/Measure/testMeasure2'
           },
           {
             name: 'subject',
@@ -895,7 +897,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUrl: 'http://example.com/Measure/testMeasure2|2.0.0'
+            valueCanonical: 'http://example.com/Measure/testMeasure'
           },
           {
             name: 'subject',
@@ -907,12 +909,12 @@ describe('Check collect-data logic', () => {
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
-          'Measure with url http://example.com/Measure/nonExist not found.'
+          'Multiple versions of http://example.com/Measure/testMeasure were found.'
         );
       });
   });
 
-  test('check 400 returned for measure by url with version that cannot be found', async () => {
+  test('check 404 returned for measure by url with version that cannot be found', async () => {
     await supertest(app.server)
       .post('/Measure/$collect-data')
       .send({
@@ -922,7 +924,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUrl: 'http://example.com/Measure/testMeasure2|2.0.0'
+            valueCanonical: 'http://example.com/Measure/testMeasure2|2.1.0'
           },
           {
             name: 'subject',
@@ -930,16 +932,16 @@ describe('Check collect-data logic', () => {
           }
         ]
       })
-      .expect(400)
+      .expect(404)
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
-          'Measure with url http://example.com/Measure/nonExist not found.'
+          'Measure with url http://example.com/Measure/testMeasure2|2.1.0 not found.'
         );
       });
   });
 
-  test('check 400 returned for measure by url that cannot be found', async () => {
+  test('check 404 returned for measure by url that cannot be found', async () => {
     await supertest(app.server)
       .post('/Measure/$collect-data')
       .send({
@@ -949,7 +951,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUrl: 'http://example.com/Measure/nonExist'
+            valueCanonical: 'http://example.com/Measure/nonExist'
           },
           {
             name: 'subject',
@@ -957,7 +959,7 @@ describe('Check collect-data logic', () => {
           }
         ]
       })
-      .expect(400)
+      .expect(404)
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
@@ -1033,7 +1035,7 @@ describe('Check collect-data logic', () => {
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
-          'The following parameters are unrecognized by the server: unrecognizedParam.'
+          'The following parameters are unrecognized by the server: measureId, unrecognizedParam.'
         );
       });
   });
@@ -1048,7 +1050,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'measureUrl',
-            valueUrl: 'http://example.com/Measure/testMeasure2'
+            valueCanonical: 'http://example.com/Measure/testMeasure2'
           },
           {
             name: 'subject',

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -770,7 +770,7 @@ describe('Check organizeOutputBy=Patient export logic', () => {
 });
 
 describe('Check collect-data logic', () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     await createTestResourceWithConnect(testPatient, 'Patient');
     await createTestResource(testEncounter, 'Encounter');
     await createTestResource(testCondition, 'Condition');
@@ -780,10 +780,10 @@ describe('Check collect-data logic', () => {
     await app.ready();
   });
 
-  test('check 200 returned for valid GET request - one measure, single code', async () => {
+  test('check 200 returned for valid GET request - one measure with url, single code', async () => {
     await supertest(app.server)
       .get(
-        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureId=testMeasure2&subject=Patient/testPatient'
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http://example.com/Measure/testMeasure2&subject=Patient/testPatient'
       )
       .expect(200)
       .then(response => {
@@ -798,7 +798,25 @@ describe('Check collect-data logic', () => {
       });
   });
 
-  test('check 200 returned for valid POST request - one measure, single code', async () => {
+  test('check 200 returned for valid GET request - one measure with url and version, single code', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http://example.com/Measure/testMeasure2|1.0.1&subject=Patient/testPatient'
+      )
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        ); // check correct types
+        expect(response.body[0].entry).toEqual(
+          expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
+        ); // check specific resources
+      });
+  });
+
+  test('check 200 returned for valid POST request - one measure with url, single code', async () => {
     await supertest(app.server)
       .post('/Measure/$collect-data')
       .send({
@@ -807,8 +825,8 @@ describe('Check collect-data logic', () => {
           { name: 'periodStart', valueDate: '2025-01-01' },
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
-            name: 'measureId',
-            valueId: 'testMeasure2'
+            name: 'measureUrl',
+            valueUri: 'http://example.com/Measure/testMeasure2|1.0.1'
           },
           {
             name: 'subject',
@@ -829,7 +847,7 @@ describe('Check collect-data logic', () => {
       });
   });
 
-  test('check 200 returned for valid POST request - one measure, valueset and single code', async () => {
+  test('check 200 returned for valid POST request - two measures with url', async () => {
     await supertest(app.server)
       .post('/Measure/$collect-data')
       .send({
@@ -838,46 +856,12 @@ describe('Check collect-data logic', () => {
           { name: 'periodStart', valueDate: '2025-01-01' },
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
-            name: 'measureId',
-            valueId: 'testMeasure'
+            name: 'measureUrl',
+            valueUri: 'http://example.com/Measure/testMeasure'
           },
           {
-            name: 'subject',
-            valueString: 'Patient/testPatient'
-          }
-        ]
-      })
-      .expect(200)
-      .then(response => {
-        expect(response.body).toBeDefined();
-        expect(response.body[0].entry).toHaveLength(3); //expect 1 measure report, encounter, and condition
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
-          expect.arrayContaining(['Condition', 'Encounter', 'MeasureReport'])
-        ); // check correct types
-        expect(response.body[0].entry).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' }),
-            expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
-          ])
-        ); // check specific resources
-      });
-  });
-
-  test('check 200 returned for valid POST request - two measures', async () => {
-    await supertest(app.server)
-      .post('/Measure/$collect-data')
-      .send({
-        resourceType: 'Parameters',
-        parameter: [
-          { name: 'periodStart', valueDate: '2025-01-01' },
-          { name: 'periodEnd', valueDate: '2025-12-31' },
-          {
-            name: 'measureId',
-            valueId: 'testMeasure'
-          },
-          {
-            name: 'measureId',
-            valueId: 'testMeasure2'
+            name: 'measureUrl',
+            valueUri: 'http://example.com/Measure/testMeasure2|1.0.1'
           },
           {
             name: 'subject',
@@ -898,6 +882,128 @@ describe('Check collect-data logic', () => {
             expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
           ])
         ); // check specific resources
+      });
+  });
+
+  test('check 400 returned for measure by url without version specified when there are multiple versions', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueUrl: 'http://example.com/Measure/testMeasure2|2.0.0'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'Measure with url http://example.com/Measure/nonExist not found.'
+        );
+      });
+  });
+
+  test('check 400 returned for measure by url with version that cannot be found', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueUrl: 'http://example.com/Measure/testMeasure2|2.0.0'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'Measure with url http://example.com/Measure/nonExist not found.'
+        );
+      });
+  });
+
+  test('check 400 returned for measure by url that cannot be found', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueUrl: 'http://example.com/Measure/nonExist'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'Measure with url http://example.com/Measure/nonExist not found.'
+        );
+      });
+  });
+
+  test('check 400 returned for invalid GET request using measureId', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureId=testMeasure2&subject=Patient/testPatient'
+      )
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following parameters are unrecognized by the server: measureId.'
+        );
+      });
+  });
+
+  test('check 400 returned for invalid POST request using measureId', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureId',
+            valueId: 'testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following parameters are unrecognized by the server: measureId.'
+        );
       });
   });
 
@@ -941,8 +1047,8 @@ describe('Check collect-data logic', () => {
           { name: 'periodStart', valueDate: '2025-01-01' },
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
-            name: 'measureId',
-            valueId: 'testMeasure2'
+            name: 'measureUrl',
+            valueUrl: 'http://example.com/Measure/testMeasure2'
           },
           {
             name: 'subject',
@@ -963,7 +1069,7 @@ describe('Check collect-data logic', () => {
       });
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await cleanUpDb();
   });
 });

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -968,6 +968,37 @@ describe('Check collect-data logic', () => {
       });
   });
 
+  test('check 400 returned for invalid POST missing measureUrl', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'subject',
+            valueString: 'Patient/testPatient'
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe('At least one measureUrl is required.');
+      });
+  });
+
+  test('check 400 returned for invalid GET request missing measureUrl', async () => {
+    await supertest(app.server)
+      .get('/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&subject=Patient/testPatient')
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe('At least one measureUrl is required.');
+      });
+  });
+
   test('check 400 returned for invalid GET request using measureId', async () => {
     await supertest(app.server)
       .get(


### PR DESCRIPTION
# Summary

Replaces measureId parameter with canonical measureUrl parameter for $collect-data.

## New behavior

`measureUrl` is now expected to be used to reference measures. Different versions of a measure with the same url can exist and must be specified with the version in the canonical.

## Code changes

`mongo.controller.js` - Added findResourceByCanonical to search for resources by canonical.

# Testing guidance

- Run unit tests.
- Test $collect-data by referencing measures by canonical url. Example parameter body using a canonical measureUrl.
     ```
     {
	"resourceType": "Parameters",
	"parameter": [
		{
			"name": "periodStart",
			"valueDate": "2023-01-01"
		},
		{
			"name": "periodEnd",
			"valueDate": "2023-12-31"
		},
		{
			"name": "measureUrl",
			"valueCanonical": "https://madie.cms.gov/Measure/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD|0.4.000"
		},
		{
			"name": "subject",
			"valueString": "Patient/f6dafa7e-15a9-4fec-baea-59d43201caf8"
		}
	   ]
     }
     ```
- Clone a measure in the database changing the version for the clone. Ensure that not providing the version in the measureUrl results in an appropriate error.