### PR TITLE
Change tacoma docker hub org to mitrehealthdocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Debugging with terminal input can be facilitated with `stdin_open: true` and `tt
 
 #### Building new Docker Images
 
-If you have permission to push to the tacoma organization on Docker Hub, simply run `docker-build.sh` to build a multi-platform image and push to docker hub tagged as `latest`.
+If you have permission to push to the mitrehealthdocker organization on Docker Hub, simply run `docker-build.sh` to build a multi-platform image and push to docker hub tagged as `latest`.
 
 ## Usage
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker buildx build --platform linux/arm64,linux/amd64 -t tacoma/bulk-export-server:latest -f Dockerfile . --push
+docker buildx build --platform linux/arm64,linux/amd64 -t mitrehealthdocker/bulk-export-server:latest -f Dockerfile . --push

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fhir:
-    image: tacoma/bulk-export-server
+    image: mitrehealthdocker/bulk-export-server
     depends_on:
       - mongo
       - redis


### PR DESCRIPTION
# Summary

Moving publish location from tacoma/bulk-export-server to mitrehealthdocker/bulk-export-server.

## New behavior

None

## Code changes

None

# Testing guidance

N/A
