### PR TITLE
Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ Endpoint: `POST [fhir base]/bulkstatus/[client id]/kickoff-import`
 
 All of the `$export` endpoints also support acting as a kickoff mechanism for a `$bulk-submit` operation. The user can pass in a `bulkSubmitEndpoint` parameter which specifies the location of the server endpoint for `$bulk-submit` (i.e. `{FHIR base url}/$bulk-submit`). The presence of this parameter indicates that a `$bulk-submit` operation should be kicked off. The user may also include the `bulkSubmitStatusEndpoint` parameter specifying the `$bulk-submit-status` operation endpoint. See https://hackmd.io/@argonaut/rJoqHZrPle#Relationship-to-Bulk-Export for more information.
 
+#### Measure Collect Data
+
+FHIR Operation to obtain data of interest for one or more Measure resources, organized by a specified patient subject. This implementation supports a limited subset of the [Da Vinci DEQM $collect-data operation](https://hl7.org/fhir/uv/deqm/2026May/en/OperationDefinition-collect-data.html) and returns a Parameters object containing FHIR Bundles, organized by subject. Each returned Bundle contains the patient resources found for the Measure data requirements and a data-collection MeasureReport for each requested Measure.
+
+Endpoint: `POST [fhir base]/Measure/$collect-data`
+
+The collect-data parameters must be supplied using a FHIR [Parameters Resource](http://hl7.org/fhir/R4/parameters.html) in the request body. Alternatively, a GET request (`GET [fhir base]/Measure/$collect-data`) can be sent using URL parameters as long as all parameters are primitive types. 
+
+The currently supported parameters are `periodStart`, `periodEnd`, `measureUrl`, `subject`, and `subjectGroup`. At least one `measureUrl` is required, and multiple `measureUrl` parameters may be supplied. Measures are resolved by canonical URL, with an optional version suffix (for example, `http://example.com/Measure/testMeasure|1.0.0`). If a version is not supplied and multiple Measure versions match the canonical URL, the server returns an error. The `subject` parameter should identify a patient or group using the `Patient/[id]` or `Group/[id]` format. The `subjectGroup` parameter should pass a Group resource that identifies a set of patients.
+
 ## Supported Query Parameters
 
 The server supports the following query parameters:

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -1,4 +1,9 @@
-const { addPendingBulkExportRequest, findResourceById, findResourceByCanonical } = require('../util/mongo.controller');
+const {
+  addPendingBulkExportRequest,
+  findResourceById,
+  findResourceByCanonical,
+  findResourcesWithQuery
+} = require('../util/mongo.controller');
 const supportedResources = require('../util/supportedResources').filter(r => r !== 'ValueSet'); //exclude ValueSet (may be stored but not exported)
 const exportQueue = require('../resources/exportQueue');
 const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
@@ -179,6 +184,24 @@ const groupBulkExport = async (request, reply) => {
   }
 };
 
+// Preferable over truthy check to allow for boolean or 0
+function paramPresent(parameters, param) {
+  const value = parameters[param];
+  return value !== undefined && value !== null && value !== '';
+}
+
+// Accept bulkSubmitStatusEndpoint, but currently do nothing with it
+const EXPORT_RECOGNIZED_PARAMS = [
+  '_outputFormat',
+  '_type',
+  '_typeFilter',
+  'patient',
+  '_elements',
+  'organizeOutputBy',
+  'bulkSubmitEndpoint',
+  'bulkSubmitStatusEndpoint'
+];
+
 /**
  * Checks that the parameters input to $export are valid. Returns true if all the
  * export params are valid, meaning no errors were thrown in the process.
@@ -191,7 +214,7 @@ function validateExportParams(parameters, reply) {
    * account for abbreviated representations of ndjson
    */
   const ACCEPTEDOUTPUTFORMATS = ['application/fhir+ndjson', 'application/ndjson+fhir', 'application/ndjson', 'ndjson'];
-  if (parameters._outputFormat) {
+  if (paramPresent(parameters, '_outputFormat')) {
     if (!ACCEPTEDOUTPUTFORMATS.includes(parameters._outputFormat)) {
       reply
         .code(400)
@@ -204,7 +227,7 @@ function validateExportParams(parameters, reply) {
     }
   }
 
-  if (parameters.organizeOutputBy && parameters.organizeOutputBy !== 'Patient') {
+  if (paramPresent(parameters, 'organizeOutputBy') && parameters.organizeOutputBy !== 'Patient') {
     reply.code(400).send(
       createOperationOutcome(`Server does not support the organizeOutputBy parameter for values other than Patient.`, {
         issueCode: 400,
@@ -214,7 +237,7 @@ function validateExportParams(parameters, reply) {
     return false;
   }
 
-  if (parameters._type) {
+  if (paramPresent(parameters, '_type')) {
     // type filter is comma-delimited
     const requestTypes = parameters._type.split(',');
     const unsupportedTypes = [];
@@ -249,7 +272,7 @@ function validateExportParams(parameters, reply) {
     }
   }
 
-  if (parameters._typeFilter) {
+  if (paramPresent(parameters, '_typeFilter')) {
     const typeFilterArray = Array.isArray(parameters._typeFilter)
       ? parameters._typeFilter
       : parameters._typeFilter.split(',');
@@ -280,7 +303,7 @@ function validateExportParams(parameters, reply) {
   }
 
   // add validation for the _elements query param
-  if (parameters._elements) {
+  if (paramPresent(parameters, '_elements')) {
     const elementsArray = parameters._elements.split(',');
     const unsupportedResourceTypes = [];
     const unsupportedElementTypes = [];
@@ -322,11 +345,11 @@ function validateExportParams(parameters, reply) {
     }
   }
 
-  if (parameters.patient) {
-    const referenceFormat = /^Patient\/[\w-]+$/;
+  if (paramPresent(parameters, 'patient')) {
+    const referenceFormat = /^Patient\/[\w.-]+$/;
     const errorMessage = 'All patient references must be of the format "Patient/{id}" for the "patient" parameter.';
     parameters.patient.forEach(p => {
-      if (!referenceFormat.test(p.reference)) {
+      if (!referenceFormat.test(p)) {
         reply.code(400).send(createOperationOutcome(errorMessage, { issueCode: 400, severity: 'error' }));
         return false;
       }
@@ -335,19 +358,7 @@ function validateExportParams(parameters, reply) {
 
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
-    // Accept bulkSubmitStatusEndpoint, but currently do nothing with it
-    if (
-      ![
-        '_outputFormat',
-        '_type',
-        '_typeFilter',
-        'patient',
-        '_elements',
-        'organizeOutputBy',
-        'bulkSubmitEndpoint',
-        'bulkSubmitStatusEndpoint'
-      ].includes(param)
-    ) {
+    if (!EXPORT_RECOGNIZED_PARAMS.includes(param)) {
       unrecognizedParams.push(param);
     }
   });
@@ -404,12 +415,13 @@ function filterPatientResourceTypes(request, reply, types) {
  * @param {Object} reply the response object
  */
 async function validatePatientReferences(patientParam, reply) {
+  // TODO: Move validation functions like this one from this file to a new validationUtils file in the util folder
   const unknownPatientPromises = patientParam.map(async p => {
-    const splitRef = p.reference.split('/');
+    const splitRef = p.split('/');
     const patientId = splitRef[splitRef.length - 1];
     const patient = await findResourceById(patientId, 'Patient');
     if (!patient) {
-      return p.reference;
+      return p;
     }
     return null;
   });
@@ -423,8 +435,35 @@ async function validatePatientReferences(patientParam, reply) {
   return false;
 }
 
+async function collectDataPatientIds(parameters, reply) {
+  if (parameters.subject) {
+    if (parameters.subject.startsWith('Patient')) {
+      validatePatientReferences([parameters.subject], reply);
+      return [parameters.subject.split('Patient/')[1]];
+    } else if (parameters.subject.startsWith('Group')) {
+      const groupId = parameters.subject.split('Group/')[1];
+      const group = await findResourceById(groupId, 'Group');
+      if (!group) {
+        const errorMessage = `The following group id is not available on the server: ${groupId}`;
+        reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
+      }
+      return group.member.map(m => m.entity.reference.split('Patient/')[1]);
+    }
+  } else if (parameters.subjectGroup) {
+    const patientReferences = parameters.subjectGroup.member.map(m => m.entity.reference);
+    validatePatientReferences(patientReferences, reply);
+    // TODO: add at least one unit test for subjectGroup. Group defined https://hl7.org/fhir/R4/group.html
+    // Group "type" should be "person", "actual" should be true, "member" should be an array of size two where each entity is a patient reference
+    return parameters.subjectGroup.member.map(m => m.entity.reference.split('Patient/')[1]);
+  }
+
+  // if neither subject nor subjectGroup are provided, default to all patients
+  const patients = await findResourcesWithQuery({}, 'Patient', { projection: { _id: 0, id: 1 } });
+  return patients.map(patient => patient.id);
+}
+
 /**
- * Implements limited parameters for $collect-data according to https://hl7.org/fhir/us/davinci-deqm/STU5/OperationDefinition-collect-data.html
+ * Implements limited parameters for $collect-data according to https://build.fhir.org/ig/HL7/davinci-deqm/en/OperationDefinition-collect-data.html
  * Returns a set of bundles that have data of interest for the specified measures, organized by the specified subject
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object
@@ -435,7 +474,7 @@ const collectData = async (request, reply) => {
   if (validateCollectDataParams(parameters, reply)) {
     request.log.info('Measure >>> $collect-data');
 
-    const patientIds = [parameters.subject.split('Patient/')[1]];
+    const patientIds = await collectDataPatientIds(parameters, reply);
     // Check for measure resolution - errors if there are any issues with measures passed
     const measureArr = Array.isArray(parameters.measureUrl) ? parameters.measureUrl : [parameters.measureUrl];
     const measures = [];
@@ -494,30 +533,36 @@ const collectData = async (request, reply) => {
   }
 };
 
+const COLLECT_DATA_RECOGNIZED_PARAMS = [
+  'measureUrl',
+  'periodStart',
+  'periodEnd',
+  'subject',
+  'subjectGroup',
+  'reporter',
+  'reporterResource',
+  'location',
+  'lastReceivedOn',
+  'parameters',
+  'manifest',
+  'validateResources',
+  'dataEndpoint'
+];
+
+const COLLECT_DATA_SUPPORTED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd', 'subject', 'subjectGroup'];
+const COLLECT_DATA_REQUIRED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd'];
+const COLLECT_DATA_SINGLE_CARDINALITY_PARAMS = ['periodStart', 'periodEnd', 'subject', 'subjectGroup'];
+
 /**
  * Checks that the parameters input to $collect-data are valid. Returns true if all the
- * export params are valid, meaning no errors were thrown in the process.
+ * collect-data params are valid, meaning no errors were thrown in the process.
  * @param {Object} parameters object containing a combination of request parameters from request query and body
  * @param {Object} reply the response object
  */
 function validateCollectDataParams(parameters, reply) {
   let unrecognizedParams = [];
   Object.keys(parameters).forEach(param => {
-    if (
-      ![
-        'periodStart',
-        'periodEnd',
-        'measureUrl',
-        'subject',
-        'subjectGroup',
-        'practitioner',
-        'lastReceivedOn',
-        'organizationResource',
-        'organization',
-        'validateResources',
-        'dataEndpoint'
-      ].includes(param)
-    ) {
+    if (!COLLECT_DATA_RECOGNIZED_PARAMS.includes(param)) {
       unrecognizedParams.push(param);
     }
   });
@@ -533,9 +578,57 @@ function validateCollectDataParams(parameters, reply) {
     return false;
   }
 
+  const missingRequiredParams = COLLECT_DATA_REQUIRED_PARAMS.filter(param => !paramPresent(parameters, param));
+  if (missingRequiredParams.length > 0) {
+    if (missingRequiredParams.length === 1 && missingRequiredParams[0] === 'measureUrl') {
+      reply
+        .code(400)
+        .send(createOperationOutcome('At least one measureUrl is required.', { issueCode: 400, severity: 'error' }));
+    } else {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following required parameters are missing for $collect-data: ${missingRequiredParams.join(', ')}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+    }
+    return false;
+  }
+
+  const repeatedSingleCardinalityParams = COLLECT_DATA_SINGLE_CARDINALITY_PARAMS.filter(param =>
+    Array.isArray(parameters[param])
+  );
+  if (repeatedSingleCardinalityParams.length > 0) {
+    reply
+      .code(400)
+      .send(
+        createOperationOutcome(
+          `The following parameters can only be provided once for $collect-data: ${repeatedSingleCardinalityParams.join(
+            ', '
+          )}.`,
+          { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+
+  const hasSubject = paramPresent(parameters, 'subject');
+  const hasSubjectGroup = paramPresent(parameters, 'subjectGroup');
+  if (hasSubject && hasSubjectGroup) {
+    reply.code(400).send(
+      createOperationOutcome('Only one of subject or subjectGroup may be specified for $collect-data.', {
+        issueCode: 400,
+        severity: 'error'
+      })
+    );
+    return false;
+  }
+
   let unsupportedParams = [];
   Object.keys(parameters).forEach(param => {
-    if (!['periodStart', 'periodEnd', 'measureUrl', 'subject'].includes(param)) {
+    if (!COLLECT_DATA_SUPPORTED_PARAMS.includes(param)) {
       unsupportedParams.push(param);
     }
   });
@@ -550,10 +643,18 @@ function validateCollectDataParams(parameters, reply) {
       );
     return false;
   }
-  if (!parameters.measureUrl) {
-    reply
-      .code(400)
-      .send(createOperationOutcome('At least one measureUrl is required.', { issueCode: 400, severity: 'error' }));
+
+  const subjectReference = parameters.subject;
+  if (hasSubject && !/^(Patient|Group)\/[\w.-]+$/.test(subjectReference)) {
+    reply.code(400).send(
+      createOperationOutcome(
+        'The subject parameter must be a Patient or Group reference of the format "Patient/{id}".',
+        {
+          issueCode: 400,
+          severity: 'error'
+        }
+      )
+    );
     return false;
   }
   return true;

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -447,8 +447,6 @@ async function collectDataPatientIds(parameters, reply) {
         const errorMessage = `The following group id is not available on the server: ${groupId}`;
         reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
       }
-      // TODO: create a successful unit test that returns 200 for a subject that uses a Group reference,
-      // referring to a Group that exists in the database
       return group.member.map(m => m.entity.reference.split('Patient/')[1]);
     }
   } else if (parameters.subjectGroup) {

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -447,7 +447,7 @@ async function collectDataPatientIds(parameters, reply) {
         const errorMessage = `The following group id is not available on the server: ${groupId}`;
         reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
       }
-      // TODO: create a successful unit test that returns 200 for a subject that uses a Group reference, 
+      // TODO: create a successful unit test that returns 200 for a subject that uses a Group reference,
       // referring to a Group that exists in the database
       return group.member.map(m => m.entity.reference.split('Patient/')[1]);
     }
@@ -502,7 +502,6 @@ const collectData = async (request, reply) => {
       }
     }
 
-    // TODO: Bundles should be packaged into a FHIR R4 Parameters object with parameters of name: 'return' and valueBundle: each bundle?
     const bundles = await Promise.all(
       patientIds.map(async id => {
         const patient = await findResourceById(id, 'Patient');
@@ -530,7 +529,13 @@ const collectData = async (request, reply) => {
       })
     );
 
-    reply.code(200).send(bundles);
+    reply.code(200).send({
+      resourceType: 'Parameters',
+      parameter: bundles.map(bundle => ({
+        name: 'return',
+        resource: bundle
+      }))
+    });
   }
 };
 

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -4,13 +4,17 @@ const {
   findResourceByCanonical,
   findResourcesWithQuery
 } = require('../util/mongo.controller');
-const supportedResources = require('../util/supportedResources').filter(r => r !== 'ValueSet'); //exclude ValueSet (may be stored but not exported)
 const exportQueue = require('../resources/exportQueue');
 const { patientAttributePaths } = require('fhir-spec-tools/build/data/patient-attribute-paths');
 const patientResourceTypes = Object.keys(patientAttributePaths);
 const { createOperationOutcome } = require('../util/errorUtils');
 const { verifyPatientsInGroup, actualizeGroup } = require('../util/groupUtils');
 const { gatherParams } = require('../util/serviceUtils');
+const {
+  validateCollectDataParams,
+  validateExportParams,
+  validatePatientReferences
+} = require('../util/validationUtils');
 const _ = require('lodash');
 const {
   createDataExchangeMeasureReport,
@@ -184,198 +188,6 @@ const groupBulkExport = async (request, reply) => {
   }
 };
 
-// Preferable over truthy check to allow for boolean or 0
-function paramPresent(parameters, param) {
-  const value = parameters[param];
-  return value !== undefined && value !== null && value !== '';
-}
-
-// Accept bulkSubmitStatusEndpoint, but currently do nothing with it
-const EXPORT_RECOGNIZED_PARAMS = [
-  '_outputFormat',
-  '_type',
-  '_typeFilter',
-  'patient',
-  '_elements',
-  'organizeOutputBy',
-  'bulkSubmitEndpoint',
-  'bulkSubmitStatusEndpoint'
-];
-
-/**
- * Checks that the parameters input to $export are valid. Returns true if all the
- * export params are valid, meaning no errors were thrown in the process.
- * @param {Object} parameters object containing a combination of request parameters from request query and body
- * @param {Object} reply the response object
- */
-function validateExportParams(parameters, reply) {
-  /**
-   * According to http://hl7.org/fhir/async.html, we should also
-   * account for abbreviated representations of ndjson
-   */
-  const ACCEPTEDOUTPUTFORMATS = ['application/fhir+ndjson', 'application/ndjson+fhir', 'application/ndjson', 'ndjson'];
-  if (paramPresent(parameters, '_outputFormat')) {
-    if (!ACCEPTEDOUTPUTFORMATS.includes(parameters._outputFormat)) {
-      reply
-        .code(400)
-        .send(
-          new Error(
-            `The following output format is not supported for _outputFormat param for $export: ${parameters._outputFormat}`
-          )
-        );
-      return false;
-    }
-  }
-
-  if (paramPresent(parameters, 'organizeOutputBy') && parameters.organizeOutputBy !== 'Patient') {
-    reply.code(400).send(
-      createOperationOutcome(`Server does not support the organizeOutputBy parameter for values other than Patient.`, {
-        issueCode: 400,
-        severity: 'error'
-      })
-    );
-    return false;
-  }
-
-  if (paramPresent(parameters, '_type')) {
-    // type filter is comma-delimited
-    const requestTypes = parameters._type.split(',');
-    const unsupportedTypes = [];
-    requestTypes.forEach(type => {
-      if (!supportedResources.includes(type)) {
-        unsupportedTypes.push(type);
-      }
-    });
-    if (unsupportedTypes.length > 0) {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `The following resourceTypes are not supported for _type param for $export: ${unsupportedTypes.join(
-              ', '
-            )}.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-      return false;
-    }
-    if (parameters.organizeOutputBy === 'Patient' && !requestTypes.includes('Patient')) {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `When _type is specified with organizeOutputBy Patient, the Patient type must be included in the _type parameter.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-      return false;
-    }
-  }
-
-  if (paramPresent(parameters, '_typeFilter')) {
-    const typeFilterArray = Array.isArray(parameters._typeFilter)
-      ? parameters._typeFilter
-      : parameters._typeFilter.split(',');
-    const unsupportedTypeFilterTypes = [];
-    typeFilterArray.forEach(line => {
-      const resourceType = line.substring(0, line.indexOf('?'));
-      // consider the query "unsupported" if no resource type is provided in query
-      if (!resourceType) {
-        unsupportedTypeFilterTypes.push(line);
-        // consider the query "unsupported" if the resource type is not supported by the server
-      } else if (!supportedResources.includes(resourceType)) {
-        unsupportedTypeFilterTypes.push(resourceType);
-      }
-    });
-    if (unsupportedTypeFilterTypes.length > 0) {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `The following resourceTypes are not supported for _typeFilter param for $export: ${unsupportedTypeFilterTypes.join(
-              ', '
-            )}.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-      return false;
-    }
-  }
-
-  // add validation for the _elements query param
-  if (paramPresent(parameters, '_elements')) {
-    const elementsArray = parameters._elements.split(',');
-    const unsupportedResourceTypes = [];
-    const unsupportedElementTypes = [];
-    elementsArray.forEach(line => {
-      // split each of the elements up by a '.' if it has one. If it does, the first part is the resourceType and the second is the element name
-      // if there is no '.', we assume that the element is just the element name
-      let resourceType = 'all';
-      if (line.includes('.')) {
-        resourceType = line.split('.')[0];
-        if (!supportedResources.includes(resourceType)) {
-          unsupportedResourceTypes.push(resourceType);
-        }
-      }
-    });
-    if (unsupportedResourceTypes.length > 0) {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `The following resourceTypes are not supported for _element param for $export: ${unsupportedResourceTypes.join(
-              ', '
-            )}.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-      return false;
-    } else if (unsupportedElementTypes.length > 0) {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `The following resourceType and element names are not supported for _element param for $export: ${unsupportedResourceTypes.join(
-              ', '
-            )}.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-      return false;
-    }
-  }
-
-  if (paramPresent(parameters, 'patient')) {
-    const referenceFormat = /^Patient\/[\w.-]+$/;
-    const errorMessage = 'All patient references must be of the format "Patient/{id}" for the "patient" parameter.';
-    parameters.patient.forEach(p => {
-      if (!referenceFormat.test(p)) {
-        reply.code(400).send(createOperationOutcome(errorMessage, { issueCode: 400, severity: 'error' }));
-        return false;
-      }
-    });
-  }
-
-  let unrecognizedParams = [];
-  Object.keys(parameters).forEach(param => {
-    if (!EXPORT_RECOGNIZED_PARAMS.includes(param)) {
-      unrecognizedParams.push(param);
-    }
-  });
-  if (unrecognizedParams.length > 0) {
-    reply
-      .code(400)
-      .send(
-        createOperationOutcome(
-          `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
-          { issueCode: 400, severity: 'error' }
-        )
-      );
-    return false;
-  }
-  return true;
-}
-
 /**
  * Checks provided types against the recommended resource types for patient-level export.
  * Filters resource types that do not appear in the patient compartment definition and throws
@@ -406,58 +218,6 @@ function filterPatientResourceTypes(request, reply, types) {
     );
   }
   return filteredTypes;
-}
-
-/**
- * Validates whether all the specified patients are available in the database.
- * Throws OperationOutcome if patients are specified that do not exist in the database.
- * @param {Array} patientParam array of patient references
- * @param {Object} reply the response object
- */
-async function validatePatientReferences(patientParam, reply) {
-  // TODO: Move validation functions like this one from this file to a new validationUtils file in the util folder
-  const unknownPatientPromises = patientParam.map(async p => {
-    const splitRef = p.split('/');
-    const patientId = splitRef[splitRef.length - 1];
-    const patient = await findResourceById(patientId, 'Patient');
-    if (!patient) {
-      return p;
-    }
-    return null;
-  });
-
-  const results = (await Promise.all(unknownPatientPromises)).filter(p => p);
-
-  if (results.length > 0) {
-    const errorMessage = `The following patient ids are not available on the server: ${results.join(', ')}`;
-    reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
-  }
-  return false;
-}
-
-async function collectDataPatientIds(parameters, reply) {
-  if (parameters.subject) {
-    if (parameters.subject.startsWith('Patient')) {
-      validatePatientReferences([parameters.subject], reply);
-      return [parameters.subject.split('Patient/')[1]];
-    } else if (parameters.subject.startsWith('Group')) {
-      const groupId = parameters.subject.split('Group/')[1];
-      const group = await findResourceById(groupId, 'Group');
-      if (!group) {
-        const errorMessage = `The following group id is not available on the server: ${groupId}`;
-        reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
-      }
-      return group.member.map(m => m.entity.reference.split('Patient/')[1]);
-    }
-  } else if (parameters.subjectGroup) {
-    const patientReferences = parameters.subjectGroup.member.map(m => m.entity.reference);
-    validatePatientReferences(patientReferences, reply);
-    return parameters.subjectGroup.member.map(m => m.entity.reference.split('Patient/')[1]);
-  }
-
-  // if neither subject nor subjectGroup are provided, default to all patients
-  const patients = await findResourcesWithQuery({}, 'Patient', { projection: { _id: 0, id: 1 } });
-  return patients.map(patient => patient.id);
 }
 
 /**
@@ -537,131 +297,36 @@ const collectData = async (request, reply) => {
   }
 };
 
-const COLLECT_DATA_RECOGNIZED_PARAMS = [
-  'measureUrl',
-  'periodStart',
-  'periodEnd',
-  'subject',
-  'subjectGroup',
-  'reporter',
-  'reporterResource',
-  'location',
-  'lastReceivedOn',
-  'parameters',
-  'manifest',
-  'validateResources',
-  'dataEndpoint'
-];
-
-const COLLECT_DATA_SUPPORTED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd', 'subject', 'subjectGroup'];
-const COLLECT_DATA_REQUIRED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd'];
-const COLLECT_DATA_SINGLE_CARDINALITY_PARAMS = ['periodStart', 'periodEnd', 'subject', 'subjectGroup'];
-
 /**
- * Checks that the parameters input to $collect-data are valid. Returns true if all the
- * collect-data params are valid, meaning no errors were thrown in the process.
- * @param {Object} parameters object containing a combination of request parameters from request query and body
+ * Collects patient ids for a collect-data request from a Patient subject, Group subject,
+ * subjectGroup parameter, or all available patients when no subject filter is provided.
+ * @param {Object} parameters object containing collect-data request parameters
  * @param {Object} reply the response object
+ * @returns {Promise<string[]>} array of patient ids to collect data for
  */
-function validateCollectDataParams(parameters, reply) {
-  let unrecognizedParams = [];
-  Object.keys(parameters).forEach(param => {
-    if (!COLLECT_DATA_RECOGNIZED_PARAMS.includes(param)) {
-      unrecognizedParams.push(param);
+async function collectDataPatientIds(parameters, reply) {
+  if (parameters.subject) {
+    if (parameters.subject.startsWith('Patient')) {
+      validatePatientReferences([parameters.subject], reply);
+      return [parameters.subject.split('Patient/')[1]];
+    } else if (parameters.subject.startsWith('Group')) {
+      const groupId = parameters.subject.split('Group/')[1];
+      const group = await findResourceById(groupId, 'Group');
+      if (!group) {
+        const errorMessage = `The following group id is not available on the server: ${groupId}`;
+        reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
+      }
+      return group.member.map(m => m.entity.reference.split('Patient/')[1]);
     }
-  });
-  if (unrecognizedParams.length > 0) {
-    reply
-      .code(400)
-      .send(
-        createOperationOutcome(
-          `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
-          { issueCode: 400, severity: 'error' }
-        )
-      );
-    return false;
+  } else if (parameters.subjectGroup) {
+    const patientReferences = parameters.subjectGroup.member.map(m => m.entity.reference);
+    validatePatientReferences(patientReferences, reply);
+    return parameters.subjectGroup.member.map(m => m.entity.reference.split('Patient/')[1]);
   }
 
-  const missingRequiredParams = COLLECT_DATA_REQUIRED_PARAMS.filter(param => !paramPresent(parameters, param));
-  if (missingRequiredParams.length > 0) {
-    if (missingRequiredParams.length === 1 && missingRequiredParams[0] === 'measureUrl') {
-      reply
-        .code(400)
-        .send(createOperationOutcome('At least one measureUrl is required.', { issueCode: 400, severity: 'error' }));
-    } else {
-      reply
-        .code(400)
-        .send(
-          createOperationOutcome(
-            `The following required parameters are missing for $collect-data: ${missingRequiredParams.join(', ')}.`,
-            { issueCode: 400, severity: 'error' }
-          )
-        );
-    }
-    return false;
-  }
-
-  const repeatedSingleCardinalityParams = COLLECT_DATA_SINGLE_CARDINALITY_PARAMS.filter(param =>
-    Array.isArray(parameters[param])
-  );
-  if (repeatedSingleCardinalityParams.length > 0) {
-    reply
-      .code(400)
-      .send(
-        createOperationOutcome(
-          `The following parameters can only be provided once for $collect-data: ${repeatedSingleCardinalityParams.join(
-            ', '
-          )}.`,
-          { issueCode: 400, severity: 'error' }
-        )
-      );
-    return false;
-  }
-
-  const hasSubject = paramPresent(parameters, 'subject');
-  const hasSubjectGroup = paramPresent(parameters, 'subjectGroup');
-  if (hasSubject && hasSubjectGroup) {
-    reply.code(400).send(
-      createOperationOutcome('Only one of subject or subjectGroup may be specified for $collect-data.', {
-        issueCode: 400,
-        severity: 'error'
-      })
-    );
-    return false;
-  }
-
-  let unsupportedParams = [];
-  Object.keys(parameters).forEach(param => {
-    if (!COLLECT_DATA_SUPPORTED_PARAMS.includes(param)) {
-      unsupportedParams.push(param);
-    }
-  });
-  if (unsupportedParams.length > 0) {
-    reply
-      .code(501)
-      .send(
-        createOperationOutcome(
-          `The following parameters are not yet supported by the server: ${unsupportedParams.join(', ')}.`,
-          { issueCode: 501, severity: 'error' }
-        )
-      );
-    return false;
-  }
-
-  const subjectReference = parameters.subject;
-  if (hasSubject && !/^(Patient|Group)\/[\w.-]+$/.test(subjectReference)) {
-    reply.code(400).send(
-      createOperationOutcome(
-        'The subject parameter must be a Patient or Group reference of the format "Patient/{id}".',
-        {
-          issueCode: 400,
-          severity: 'error'
-        }
-      )
-    );
-    return false;
-  }
-  return true;
+  // if neither subject nor subjectGroup are provided, default to all patients
+  const patients = await findResourcesWithQuery({}, 'Patient', { projection: { _id: 0, id: 1 } });
+  return patients.map(patient => patient.id);
 }
 
 module.exports = { bulkExport, patientBulkExport, groupBulkExport, collectData };

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -447,13 +447,13 @@ async function collectDataPatientIds(parameters, reply) {
         const errorMessage = `The following group id is not available on the server: ${groupId}`;
         reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
       }
+      // TODO: create a successful unit test that returns 200 for a subject that uses a Group reference, 
+      // referring to a Group that exists in the database
       return group.member.map(m => m.entity.reference.split('Patient/')[1]);
     }
   } else if (parameters.subjectGroup) {
     const patientReferences = parameters.subjectGroup.member.map(m => m.entity.reference);
     validatePatientReferences(patientReferences, reply);
-    // TODO: add at least one unit test for subjectGroup. Group defined https://hl7.org/fhir/R4/group.html
-    // Group "type" should be "person", "actual" should be true, "member" should be an array of size two where each entity is a patient reference
     return parameters.subjectGroup.member.map(m => m.entity.reference.split('Patient/')[1]);
   }
 
@@ -502,6 +502,7 @@ const collectData = async (request, reply) => {
       }
     }
 
+    // TODO: Bundles should be packaged into a FHIR R4 Parameters object with parameters of name: 'return' and valueBundle: each bundle?
     const bundles = await Promise.all(
       patientIds.map(async id => {
         const patient = await findResourceById(id, 'Patient');

--- a/src/services/export.service.js
+++ b/src/services/export.service.js
@@ -221,7 +221,7 @@ function filterPatientResourceTypes(request, reply, types) {
 }
 
 /**
- * Implements limited parameters for $collect-data according to https://build.fhir.org/ig/HL7/davinci-deqm/en/OperationDefinition-collect-data.html
+ * Implements limited parameters for $collect-data according to https://hl7.org/fhir/uv/deqm/2026May/en/OperationDefinition-collect-data.html
  * Returns a set of bundles that have data of interest for the specified measures, organized by the specified subject
  * @param {Object} request the request object passed in by the user
  * @param {Object} reply the response object

--- a/src/util/collectDataUtils.js
+++ b/src/util/collectDataUtils.js
@@ -46,7 +46,7 @@ function createPatientBundle(patient, resources, measureReports) {
 
 /**
  * Creates a FHIR data exchange MeasureReport from measure and subject data
- * https://hl7.org/fhir/us/davinci-deqm/STU5/StructureDefinition-datax-measurereport-deqm.html
+ * https://hl7.org/fhir/uv/deqm/2026May/en/StructureDefinition-deqm-dataexchangemeasurereport.html
  * @param measure FHIR Measure
  * @param measurementPeriod FHIR Period representing the measurement period
  * @param subjectId the patient id the MeasureReport is associated with

--- a/src/util/exportToNDJson.js
+++ b/src/util/exportToNDJson.js
@@ -150,9 +150,8 @@ const exportToNDJson = async jobOptions => {
     const exportTypes = systemLevelExport ? requestTypes.filter(t => t !== 'ValueSet') : requestTypes;
 
     // if 'patient' parameter is present, apply additional filtering on the resources related to these patients
-    // strip off '.reference' to align with the format of the patientIds array
     const patientParamIds = patient?.map(p => {
-      const splitRef = p.reference.split('/');
+      const splitRef = p.split('/');
       return splitRef[splitRef.length - 1];
     });
 

--- a/src/util/groupUtils.js
+++ b/src/util/groupUtils.js
@@ -47,8 +47,8 @@ function verifyPatientsInGroup(patientParam, groupId, groupMembers, reply) {
   const unknownPatientReferences = [];
 
   patientParam.forEach(p => {
-    if (!groupMembers.find(member => member === p.reference)) {
-      unknownPatientReferences.push(p.reference);
+    if (!groupMembers.find(member => member === p)) {
+      unknownPatientReferences.push(p);
     }
   });
 

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -46,7 +46,7 @@ function gatherParams(method, query, body, reply) {
             acc[e.name].push(e.valueCanonical);
           }
         } else {
-          // For now, all usable params are expected to be stored under one of these eight keys
+          // For now, all usable params are expected to be stored under one of these seven keys
           acc[e.name] =
             e.valueDate ||
             e.valueString ||

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -30,7 +30,9 @@ function gatherParams(method, query, body, reply) {
   const params = { ...query };
   if (body && body.parameter) {
     body.parameter.reduce((acc, e) => {
-      if (!e.resource) {
+      if (e.resource) {
+        acc[e.name] = e.resource;
+      } else {
         if (e.name === 'patient') {
           if (!acc[e.name]) {
             acc[e.name] = [e.valueReference.reference];
@@ -52,8 +54,7 @@ function gatherParams(method, query, body, reply) {
             e.valueCanonical ||
             e.valueCode ||
             e.valueReference?.reference ||
-            e.valueBoolean ||
-            e.valueGroup;
+            e.valueBoolean;
         }
       }
       return acc;

--- a/src/util/serviceUtils.js
+++ b/src/util/serviceUtils.js
@@ -33,9 +33,9 @@ function gatherParams(method, query, body, reply) {
       if (!e.resource) {
         if (e.name === 'patient') {
           if (!acc[e.name]) {
-            acc[e.name] = [e.valueReference];
+            acc[e.name] = [e.valueReference.reference];
           } else {
-            acc[e.name].push(e.valueReference);
+            acc[e.name].push(e.valueReference.reference);
           }
         } else if (e.name === 'measureUrl') {
           if (!acc[e.name]) {
@@ -44,9 +44,16 @@ function gatherParams(method, query, body, reply) {
             acc[e.name].push(e.valueCanonical);
           }
         } else {
-          // For now, all usable params are expected to be stored under one of these six keys
+          // For now, all usable params are expected to be stored under one of these eight keys
           acc[e.name] =
-            e.valueDate || e.valueString || e.valueId || e.valueCanonical || e.valueCode || e.valueReference;
+            e.valueDate ||
+            e.valueString ||
+            e.valueId ||
+            e.valueCanonical ||
+            e.valueCode ||
+            e.valueReference?.reference ||
+            e.valueBoolean ||
+            e.valueGroup;
         }
       }
       return acc;

--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -312,6 +312,15 @@ function validateCollectDataParams(parameters, reply) {
     );
     return false;
   }
+  if (hasSubjectGroup && parameters.subjectGroup.resourceType !== 'Group') {
+    reply.code(400).send(
+      createOperationOutcome('Parameter subjectGroup must be a resource of type Group.', {
+        issueCode: 400,
+        severity: 'error'
+      })
+    );
+    return false;
+  }
 
   let unsupportedParams = [];
   Object.keys(parameters).forEach(param => {

--- a/src/util/validationUtils.js
+++ b/src/util/validationUtils.js
@@ -1,0 +1,354 @@
+const { findResourceById } = require('./mongo.controller');
+const supportedResources = require('./supportedResources').filter(r => r !== 'ValueSet'); //exclude ValueSet (may be stored but not exported)
+const { createOperationOutcome } = require('./errorUtils');
+
+// Preferable over truthy check to allow for boolean or 0
+function paramPresent(parameters, param) {
+  const value = parameters[param];
+  return value !== undefined && value !== null && value !== '';
+}
+
+// Accept bulkSubmitStatusEndpoint, but currently do nothing with it
+const EXPORT_RECOGNIZED_PARAMS = [
+  '_outputFormat',
+  '_type',
+  '_typeFilter',
+  'patient',
+  '_elements',
+  'organizeOutputBy',
+  'bulkSubmitEndpoint',
+  'bulkSubmitStatusEndpoint'
+];
+
+const COLLECT_DATA_RECOGNIZED_PARAMS = [
+  'measureUrl',
+  'periodStart',
+  'periodEnd',
+  'subject',
+  'subjectGroup',
+  'reporter',
+  'reporterResource',
+  'location',
+  'lastReceivedOn',
+  'parameters',
+  'manifest',
+  'validateResources',
+  'dataEndpoint'
+];
+
+const COLLECT_DATA_SUPPORTED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd', 'subject', 'subjectGroup'];
+const COLLECT_DATA_REQUIRED_PARAMS = ['measureUrl', 'periodStart', 'periodEnd'];
+const COLLECT_DATA_SINGLE_CARDINALITY_PARAMS = ['periodStart', 'periodEnd', 'subject', 'subjectGroup'];
+
+/**
+ * Checks that the parameters input to $export are valid. Returns true if all the
+ * export params are valid, meaning no errors were thrown in the process.
+ * @param {Object} parameters object containing a combination of request parameters from request query and body
+ * @param {Object} reply the response object
+ */
+function validateExportParams(parameters, reply) {
+  /**
+   * According to http://hl7.org/fhir/async.html, we should also
+   * account for abbreviated representations of ndjson
+   */
+  const ACCEPTEDOUTPUTFORMATS = ['application/fhir+ndjson', 'application/ndjson+fhir', 'application/ndjson', 'ndjson'];
+  if (paramPresent(parameters, '_outputFormat')) {
+    if (!ACCEPTEDOUTPUTFORMATS.includes(parameters._outputFormat)) {
+      reply
+        .code(400)
+        .send(
+          new Error(
+            `The following output format is not supported for _outputFormat param for $export: ${parameters._outputFormat}`
+          )
+        );
+      return false;
+    }
+  }
+
+  if (paramPresent(parameters, 'organizeOutputBy') && parameters.organizeOutputBy !== 'Patient') {
+    reply.code(400).send(
+      createOperationOutcome(`Server does not support the organizeOutputBy parameter for values other than Patient.`, {
+        issueCode: 400,
+        severity: 'error'
+      })
+    );
+    return false;
+  }
+
+  if (paramPresent(parameters, '_type')) {
+    // type filter is comma-delimited
+    const requestTypes = parameters._type.split(',');
+    const unsupportedTypes = [];
+    requestTypes.forEach(type => {
+      if (!supportedResources.includes(type)) {
+        unsupportedTypes.push(type);
+      }
+    });
+    if (unsupportedTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceTypes are not supported for _type param for $export: ${unsupportedTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    }
+    if (parameters.organizeOutputBy === 'Patient' && !requestTypes.includes('Patient')) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `When _type is specified with organizeOutputBy Patient, the Patient type must be included in the _type parameter.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    }
+  }
+
+  if (paramPresent(parameters, '_typeFilter')) {
+    const typeFilterArray = Array.isArray(parameters._typeFilter)
+      ? parameters._typeFilter
+      : parameters._typeFilter.split(',');
+    const unsupportedTypeFilterTypes = [];
+    typeFilterArray.forEach(line => {
+      const resourceType = line.substring(0, line.indexOf('?'));
+      // consider the query "unsupported" if no resource type is provided in query
+      if (!resourceType) {
+        unsupportedTypeFilterTypes.push(line);
+        // consider the query "unsupported" if the resource type is not supported by the server
+      } else if (!supportedResources.includes(resourceType)) {
+        unsupportedTypeFilterTypes.push(resourceType);
+      }
+    });
+    if (unsupportedTypeFilterTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceTypes are not supported for _typeFilter param for $export: ${unsupportedTypeFilterTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    }
+  }
+
+  // add validation for the _elements query param
+  if (paramPresent(parameters, '_elements')) {
+    const elementsArray = parameters._elements.split(',');
+    const unsupportedResourceTypes = [];
+    const unsupportedElementTypes = [];
+    elementsArray.forEach(line => {
+      // split each of the elements up by a '.' if it has one. If it does, the first part is the resourceType and the second is the element name
+      // if there is no '.', we assume that the element is just the element name
+      let resourceType = 'all';
+      if (line.includes('.')) {
+        resourceType = line.split('.')[0];
+        if (!supportedResources.includes(resourceType)) {
+          unsupportedResourceTypes.push(resourceType);
+        }
+      }
+    });
+    if (unsupportedResourceTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceTypes are not supported for _element param for $export: ${unsupportedResourceTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    } else if (unsupportedElementTypes.length > 0) {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following resourceType and element names are not supported for _element param for $export: ${unsupportedResourceTypes.join(
+              ', '
+            )}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+      return false;
+    }
+  }
+
+  if (paramPresent(parameters, 'patient')) {
+    const referenceFormat = /^Patient\/[\w.-]+$/;
+    const errorMessage = 'All patient references must be of the format "Patient/{id}" for the "patient" parameter.';
+    parameters.patient.forEach(p => {
+      if (!referenceFormat.test(p)) {
+        reply.code(400).send(createOperationOutcome(errorMessage, { issueCode: 400, severity: 'error' }));
+        return false;
+      }
+    });
+  }
+
+  let unrecognizedParams = [];
+  Object.keys(parameters).forEach(param => {
+    if (!EXPORT_RECOGNIZED_PARAMS.includes(param)) {
+      unrecognizedParams.push(param);
+    }
+  });
+  if (unrecognizedParams.length > 0) {
+    reply
+      .code(400)
+      .send(
+        createOperationOutcome(
+          `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
+          { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Validates whether all the specified patients are available in the database.
+ * Throws OperationOutcome if patients are specified that do not exist in the database.
+ * @param {Array} patientParam array of patient references
+ * @param {Object} reply the response object
+ */
+async function validatePatientReferences(patientParam, reply) {
+  const unknownPatientPromises = patientParam.map(async p => {
+    const splitRef = p.split('/');
+    const patientId = splitRef[splitRef.length - 1];
+    const patient = await findResourceById(patientId, 'Patient');
+    if (!patient) {
+      return p;
+    }
+    return null;
+  });
+
+  const results = (await Promise.all(unknownPatientPromises)).filter(p => p);
+
+  if (results.length > 0) {
+    const errorMessage = `The following patient ids are not available on the server: ${results.join(', ')}`;
+    reply.code(404).send(createOperationOutcome(errorMessage, { issueCode: 404, severity: 'error' }));
+  }
+  return false;
+}
+
+/**
+ * Checks that the parameters input to $collect-data are valid. Returns true if all the
+ * collect-data params are valid, meaning no errors were thrown in the process.
+ * @param {Object} parameters object containing a combination of request parameters from request query and body
+ * @param {Object} reply the response object
+ */
+function validateCollectDataParams(parameters, reply) {
+  let unrecognizedParams = [];
+  Object.keys(parameters).forEach(param => {
+    if (!COLLECT_DATA_RECOGNIZED_PARAMS.includes(param)) {
+      unrecognizedParams.push(param);
+    }
+  });
+  if (unrecognizedParams.length > 0) {
+    reply
+      .code(400)
+      .send(
+        createOperationOutcome(
+          `The following parameters are unrecognized by the server: ${unrecognizedParams.join(', ')}.`,
+          { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+
+  const missingRequiredParams = COLLECT_DATA_REQUIRED_PARAMS.filter(param => !paramPresent(parameters, param));
+  if (missingRequiredParams.length > 0) {
+    if (missingRequiredParams.length === 1 && missingRequiredParams[0] === 'measureUrl') {
+      reply
+        .code(400)
+        .send(createOperationOutcome('At least one measureUrl is required.', { issueCode: 400, severity: 'error' }));
+    } else {
+      reply
+        .code(400)
+        .send(
+          createOperationOutcome(
+            `The following required parameters are missing for $collect-data: ${missingRequiredParams.join(', ')}.`,
+            { issueCode: 400, severity: 'error' }
+          )
+        );
+    }
+    return false;
+  }
+
+  const repeatedSingleCardinalityParams = COLLECT_DATA_SINGLE_CARDINALITY_PARAMS.filter(param =>
+    Array.isArray(parameters[param])
+  );
+  if (repeatedSingleCardinalityParams.length > 0) {
+    reply
+      .code(400)
+      .send(
+        createOperationOutcome(
+          `The following parameters can only be provided once for $collect-data: ${repeatedSingleCardinalityParams.join(
+            ', '
+          )}.`,
+          { issueCode: 400, severity: 'error' }
+        )
+      );
+    return false;
+  }
+
+  const hasSubject = paramPresent(parameters, 'subject');
+  const hasSubjectGroup = paramPresent(parameters, 'subjectGroup');
+  if (hasSubject && hasSubjectGroup) {
+    reply.code(400).send(
+      createOperationOutcome('Only one of subject or subjectGroup may be specified for $collect-data.', {
+        issueCode: 400,
+        severity: 'error'
+      })
+    );
+    return false;
+  }
+
+  let unsupportedParams = [];
+  Object.keys(parameters).forEach(param => {
+    if (!COLLECT_DATA_SUPPORTED_PARAMS.includes(param)) {
+      unsupportedParams.push(param);
+    }
+  });
+  if (unsupportedParams.length > 0) {
+    reply
+      .code(501)
+      .send(
+        createOperationOutcome(
+          `The following parameters are not yet supported by the server: ${unsupportedParams.join(', ')}.`,
+          { issueCode: 501, severity: 'error' }
+        )
+      );
+    return false;
+  }
+
+  const subjectReference = parameters.subject;
+  if (hasSubject && !/^(Patient|Group)\/[\w.-]+$/.test(subjectReference)) {
+    reply.code(400).send(
+      createOperationOutcome(
+        'The subject parameter must be a Patient or Group reference of the format "Patient/{id}".',
+        {
+          issueCode: 400,
+          severity: 'error'
+        }
+      )
+    );
+    return false;
+  }
+  return true;
+}
+
+module.exports = {
+  validateCollectDataParams,
+  validateExportParams,
+  validatePatientReferences
+};

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -782,6 +782,15 @@ describe('Check collect-data logic', () => {
     await app.ready();
   });
 
+  const getCollectDataBundles = body => {
+    expect(body.resourceType).toEqual('Parameters');
+    expect(body.parameter).toBeDefined();
+    return body.parameter.map(parameter => {
+      expect(parameter.name).toEqual('return');
+      return parameter.resource;
+    });
+  };
+
   test('check 200 returned for valid GET request - one measure with url, single code', async () => {
     await supertest(app.server)
       .get(
@@ -790,11 +799,12 @@ describe('Check collect-data logic', () => {
       .expect(200)
       .then(response => {
         expect(response.body).toBeDefined();
-        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
           expect.arrayContaining(['Encounter', 'MeasureReport'])
         ); // check correct types
-        expect(response.body[0].entry).toEqual(
+        expect(bundles[0].entry).toEqual(
           expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
         ); // check specific resources
       });
@@ -808,11 +818,12 @@ describe('Check collect-data logic', () => {
       .expect(200)
       .then(response => {
         expect(response.body).toBeDefined();
-        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
           expect.arrayContaining(['Encounter', 'MeasureReport'])
         ); // check correct types
-        expect(response.body[0].entry).toEqual(
+        expect(bundles[0].entry).toEqual(
           expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
         ); // check specific resources
       });
@@ -839,11 +850,12 @@ describe('Check collect-data logic', () => {
       .expect(200)
       .then(response => {
         expect(response.body).toBeDefined();
-        expect(response.body[0].entry).toHaveLength(2); //expect 1 measure report and encounter
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles[0].entry).toHaveLength(2); //expect 1 measure report and encounter
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
           expect.arrayContaining(['Encounter', 'MeasureReport'])
         ); // check correct types
-        expect(response.body[0].entry).toEqual(
+        expect(bundles[0].entry).toEqual(
           expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
         ); // check specific resources
       });
@@ -868,7 +880,7 @@ describe('Check collect-data logic', () => {
             },
             {
               name: 'subjectGroup',
-              valueGroup: {
+              resource: {
                 resourceType: 'Group',
                 type: 'person',
                 actual: true,
@@ -891,8 +903,9 @@ describe('Check collect-data logic', () => {
         .expect(200)
         .then(response => {
           expect(response.body).toBeDefined();
-          expect(response.body).toHaveLength(2);
-          const measureReportSubjectReferences = response.body.map(bundle => {
+          const bundles = getCollectDataBundles(response.body);
+          expect(bundles).toHaveLength(2);
+          const measureReportSubjectReferences = bundles.map(bundle => {
             return bundle.entry.find(e => e.resource.resourceType === 'MeasureReport').resource.subject.reference;
           });
           expect(measureReportSubjectReferences).toEqual(
@@ -929,11 +942,12 @@ describe('Check collect-data logic', () => {
       .expect(200)
       .then(response => {
         expect(response.body).toBeDefined();
-        expect(response.body[0].entry).toHaveLength(4); //expect 2 measure reports, encounter, and condition
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles[0].entry).toHaveLength(4); //expect 2 measure reports, encounter, and condition
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
           expect.arrayContaining(['Condition', 'Encounter', 'MeasureReport', 'MeasureReport'])
         ); // check correct types
-        expect(response.body[0].entry).toEqual(
+        expect(bundles[0].entry).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' }),
             expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
@@ -1130,9 +1144,10 @@ describe('Check collect-data logic', () => {
       .expect(200)
       .then(response => {
         expect(response.body).toBeDefined();
-        expect(response.body).toHaveLength(1);
-        expect(response.body[0].entry).toHaveLength(2);
-        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles).toHaveLength(1);
+        expect(bundles[0].entry).toHaveLength(2);
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
           expect.arrayContaining(['Encounter', 'MeasureReport'])
         );
       });
@@ -1256,7 +1271,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'validateResources',
-            valueBoolean: 'true'
+            valueBoolean: true
           }
         ]
       })

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -289,7 +289,7 @@ describe('Check barebones bulk export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueString: 'test'
+            valueReference: { reference: 'Patient/test' }
           }
         ]
       })
@@ -311,7 +311,7 @@ describe('Check barebones bulk export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueString: 'test'
+            valueReference: { reference: 'Patient/test' }
           }
         ]
       })
@@ -451,7 +451,7 @@ describe('Check patient-level export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueReference: { reference: 'Patient/unknown_patient' }
+            valueReference: { reference: 'Patient/unknown-patient' }
           }
         ]
       })
@@ -460,7 +460,7 @@ describe('Check patient-level export logic (failure)', () => {
         expect(response.body.resourceType).toEqual('OperationOutcome');
         expect(response.body.issue[0].code).toEqual(404);
         expect(response.body.issue[0].details.text).toEqual(
-          'The following patient ids are not available on the server: Patient/unknown_patient'
+          'The following patient ids are not available on the server: Patient/unknown-patient'
         );
       });
   });
@@ -473,7 +473,7 @@ describe('Check patient-level export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueString: 'test'
+            valueReference: { reference: 'Patient/test' }
           }
         ]
       })
@@ -597,7 +597,7 @@ describe('Check group-level export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueReference: { reference: 'Patient/unknown_patient' }
+            valueReference: { reference: 'Patient/unknown-patient' }
           }
         ]
       })
@@ -606,7 +606,7 @@ describe('Check group-level export logic (failure)', () => {
         expect(response.body.resourceType).toEqual('OperationOutcome');
         expect(response.body.issue[0].code).toEqual(404);
         expect(response.body.issue[0].details.text).toEqual(
-          `The following patient ids are not members of the group ${GROUP_ID}: Patient/unknown_patient`
+          `The following patient ids are not members of the group ${GROUP_ID}: Patient/unknown-patient`
         );
       });
   });
@@ -640,7 +640,7 @@ describe('Check group-level export logic (failure)', () => {
         parameter: [
           {
             name: 'patient',
-            valueString: 'test'
+            valueReference: { reference: 'Patient/test' }
           }
         ]
       })
@@ -832,7 +832,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -867,7 +867,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -901,7 +901,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -928,7 +928,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -955,7 +955,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -964,6 +964,34 @@ describe('Check collect-data logic', () => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
           'Measure with url http://example.com/Measure/nonExist not found.'
+        );
+      });
+  });
+
+  test('check 404 for patient reference not on server', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Patient/unknownPatient'
+      )
+      .expect(404)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following patient ids are not available on the server: Patient/unknownPatient'
+        );
+      });
+  });
+
+  test('check 404 for group reference not on server', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Group/unknownGroup'
+      )
+      .expect(404)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following group id is not available on the server: unknownGroup'
         );
       });
   });
@@ -978,7 +1006,7 @@ describe('Check collect-data logic', () => {
           { name: 'periodEnd', valueDate: '2025-12-31' },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -989,6 +1017,46 @@ describe('Check collect-data logic', () => {
       });
   });
 
+  test('check 400 returned for invalid POST missing periodStart', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueCanonical: 'http://example.com/Measure/testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueReference: { reference: 'Patient/testPatient' }
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following required parameters are missing for $collect-data: periodStart.'
+        );
+      });
+  });
+
+  test('check 400 returned for invalid GET request missing periodEnd', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Patient/testPatient'
+      )
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The following required parameters are missing for $collect-data: periodEnd.'
+        );
+      });
+  });
+
   test('check 400 returned for invalid GET request missing measureUrl', async () => {
     await supertest(app.server)
       .get('/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&subject=Patient/testPatient')
@@ -996,6 +1064,50 @@ describe('Check collect-data logic', () => {
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe('At least one measureUrl is required.');
+      });
+  });
+
+  test('check 200 returned when neither subject nor subjectGroup is provided', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2'
+      )
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].entry).toHaveLength(2);
+        expect(response.body[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        );
+      });
+  });
+
+  test('check 400 returned when subject and subjectGroup are both provided', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Patient/testPatient&subjectGroup=Group/testGroup'
+      )
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'Only one of subject or subjectGroup may be specified for $collect-data.'
+        );
+      });
+  });
+
+  test('check 400 returned for invalid subject reference', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=testPatient'
+      )
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe(
+          'The subject parameter must be a Patient or Group reference of the format "Patient/{id}".'
+        );
       });
   });
 
@@ -1027,7 +1139,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           }
         ]
       })
@@ -1054,7 +1166,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           },
           {
             name: 'unrecognizedParam',
@@ -1085,7 +1197,7 @@ describe('Check collect-data logic', () => {
           },
           {
             name: 'subject',
-            valueString: 'Patient/testPatient'
+            valueReference: { reference: 'Patient/testPatient' }
           },
           {
             name: 'validateResources',

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -779,6 +779,7 @@ describe('Check collect-data logic', () => {
     await createTestResource(testMeasureV2, 'Measure');
     await createTestResource(testMeasure2, 'Measure');
     await createTestResource(testValueSet, 'ValueSet');
+    await createTestResource(testGroup, 'Group');
     await app.ready();
   });
 
@@ -826,6 +827,25 @@ describe('Check collect-data logic', () => {
         expect(bundles[0].entry).toEqual(
           expect.arrayContaining([expect.objectContaining({ fullUrl: 'urn:uuid:testEncounter' })])
         ); // check specific resources
+      });
+  });
+
+  test('check 200 returned for valid GET request with subject Group reference', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Group/testGroup'
+      )
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles).toHaveLength(1);
+        expect(bundles[0].entry).toHaveLength(2);
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        );
+        const measureReport = bundles[0].entry.find(e => e.resource.resourceType === 'MeasureReport').resource;
+        expect(measureReport.subject.reference).toBe('Patient/testPatient');
       });
   });
 
@@ -953,6 +973,23 @@ describe('Check collect-data logic', () => {
             expect.objectContaining({ fullUrl: 'urn:uuid:test-condition' })
           ])
         ); // check specific resources
+      });
+  });
+
+  test('check 200 returned when neither subject nor subjectGroup is provided', async () => {
+    await supertest(app.server)
+      .get(
+        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2'
+      )
+      .expect(200)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        const bundles = getCollectDataBundles(response.body);
+        expect(bundles).toHaveLength(1);
+        expect(bundles[0].entry).toHaveLength(2);
+        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
+          expect.arrayContaining(['Encounter', 'MeasureReport'])
+        );
       });
   });
 
@@ -1133,23 +1170,6 @@ describe('Check collect-data logic', () => {
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe('At least one measureUrl is required.');
-      });
-  });
-
-  test('check 200 returned when neither subject nor subjectGroup is provided', async () => {
-    await supertest(app.server)
-      .get(
-        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2'
-      )
-      .expect(200)
-      .then(response => {
-        expect(response.body).toBeDefined();
-        const bundles = getCollectDataBundles(response.body);
-        expect(bundles).toHaveLength(1);
-        expect(bundles[0].entry).toHaveLength(2);
-        expect(bundles[0].entry.map(e => e.resource.resourceType)).toEqual(
-          expect.arrayContaining(['Encounter', 'MeasureReport'])
-        );
       });
   });
 

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -1175,15 +1175,73 @@ describe('Check collect-data logic', () => {
 
   test('check 400 returned when subject and subjectGroup are both provided', async () => {
     await supertest(app.server)
-      .get(
-        '/Measure/$collect-data?periodStart=2025-01-01&periodEnd=2025-12-31&measureUrl=http%3A%2F%2Fexample.com%2FMeasure%2FtestMeasure2&subject=Patient/testPatient&subjectGroup=Group/testGroup'
-      )
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueCanonical: 'http://example.com/Measure/testMeasure2'
+          },
+          {
+            name: 'subject',
+            valueReference: { reference: 'Patient/testPatient' }
+          },
+          {
+            name: 'subjectGroup',
+            resource: {
+              resourceType: 'Group',
+              type: 'person',
+              actual: true,
+              member: [
+                {
+                  entity: {
+                    reference: 'Patient/testPatient'
+                  }
+                },
+                {
+                  entity: {
+                    reference: 'Patient/testPatient2'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      })
       .expect(400)
       .then(response => {
         expect(response.body).toBeDefined();
         expect(response.body.issue[0].details.text).toBe(
           'Only one of subject or subjectGroup may be specified for $collect-data.'
         );
+      });
+  });
+
+  test('check 400 returned when incorrect reference-based subjectGroup format is provided', async () => {
+    await supertest(app.server)
+      .post('/Measure/$collect-data')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'periodStart', valueDate: '2025-01-01' },
+          { name: 'periodEnd', valueDate: '2025-12-31' },
+          {
+            name: 'measureUrl',
+            valueCanonical: 'http://example.com/Measure/testMeasure2'
+          },
+          {
+            name: 'subjectGroup',
+            valueReference: { reference: 'Group/testGroup' }
+          }
+        ]
+      })
+      .expect(400)
+      .then(response => {
+        expect(response.body).toBeDefined();
+        expect(response.body.issue[0].details.text).toBe('Parameter subjectGroup must be a resource of type Group.');
       });
   });
 

--- a/test/services/export.service.test.js
+++ b/test/services/export.service.test.js
@@ -849,6 +849,61 @@ describe('Check collect-data logic', () => {
       });
   });
 
+  test('check 200 returned for valid POST request with subjectGroup', async () => {
+    const secondPatient = { ...testPatient, id: 'testPatient2' };
+    delete secondPatient._id;
+    await createTestResource(secondPatient, 'Patient');
+
+    try {
+      await supertest(app.server)
+        .post('/Measure/$collect-data')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'periodStart', valueDate: '2025-01-01' },
+            { name: 'periodEnd', valueDate: '2025-12-31' },
+            {
+              name: 'measureUrl',
+              valueCanonical: 'http://example.com/Measure/testMeasure2'
+            },
+            {
+              name: 'subjectGroup',
+              valueGroup: {
+                resourceType: 'Group',
+                type: 'person',
+                actual: true,
+                member: [
+                  {
+                    entity: {
+                      reference: 'Patient/testPatient'
+                    }
+                  },
+                  {
+                    entity: {
+                      reference: 'Patient/testPatient2'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        })
+        .expect(200)
+        .then(response => {
+          expect(response.body).toBeDefined();
+          expect(response.body).toHaveLength(2);
+          const measureReportSubjectReferences = response.body.map(bundle => {
+            return bundle.entry.find(e => e.resource.resourceType === 'MeasureReport').resource.subject.reference;
+          });
+          expect(measureReportSubjectReferences).toEqual(
+            expect.arrayContaining(['Patient/testPatient', 'Patient/testPatient2'])
+          );
+        });
+    } finally {
+      await db.collection('Patient').deleteOne({ id: secondPatient.id });
+    }
+  });
+
   test('check 200 returned for valid POST request - two measures with url', async () => {
     await supertest(app.server)
       .post('/Measure/$collect-data')


### PR DESCRIPTION
# Summary
Validation for $collect-data, subjectGroup and subject Group reference support, and various other small fixes

## New behavior

- $collect-data request sends appropriate HTTP code responses for invalid input
- Can do $collect-data operation for groups of patients

Some bug fixes:
- Returns a Parameters resource (rather than array of bundles)
- Uses `valueReference` for patient references (for $collect-data subject but also for $export patient parameter)
- Does not allow underscores in patient ids (see https://hl7.org/fhir/R4/datatypes.html#id)
- More consistent handling of parameter presence to allow for boolean and 0 values (paramPresent function)

## Code changes

- Reorganizes validation logic into a util file
- Adds collectDataPatientIds to manage finding patient ids from different parameters sources
- Moves handling of valueReference.reference to serviceUtils to make parameters consistent between GET and POST
- Expands validateCollectDataParams to validate recognized, supported, required, and single cardinality parameters for $collect-data according to https://hl7.org/fhir/uv/deqm/2026May/en/OperationDefinition-collect-data.html and checks for availability of expected resources (Patient or Group) on the server. Also enforces exclusivity of subject vs subjectGroup which is anticipated to be clarified in the spec (see https://jira.hl7.org/browse/FHIR-57066 ).

# Testing guidance

- `npm run check`
- `npm run start`
- POST to http://localhost:3000/Measure/$collect-data using Insomnia. Example Parameters with subjectGroup below, but can vary parameters to check validation
```
{
"resourceType": "Parameters",
"parameter": [
   {
   	"name": "periodStart",
   	"valueDate": "2023-01-01"
   },
   {
   	"name": "periodEnd",
   	"valueDate": "2023-12-31"
   },
   {
   	"name": "measureUrl",
   	"valueCanonical": "https://madie.cms.gov/Measure/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD|0.4.000"
   },
   {
   	"name": "measureUrl",
   	"valueCanonical": "https://madie.cms.gov/Measure/CMS125FHIRBreastCancerScreening"
   },
   {
   	"name": "subjectGroup",
   	"resource": {
			"resourceType": "Group",
			"type": "person",
			"actual": "true",
			"member": [
				{
					"entity": {"reference": "Patient/f6dafa7e-15a9-4fec-baea-59d43201caf8"}
				},
				{
					"entity": {"reference": "Patient/c58acff5-248b-49c9-b18d-69e4a84a08d9"}
				}
			]
		}
   }
  ]
}
```
